### PR TITLE
feat: 新增超级岛胶囊颜色模式与可读性增强 

### DIFF
--- a/app/src/main/java/com/example/islandlyrics/core/settings/BackupCategory.kt
+++ b/app/src/main/java/com/example/islandlyrics/core/settings/BackupCategory.kt
@@ -73,6 +73,7 @@ object BackupCategories {
             SubGroup("capsule_color_share", listOf(
                 "super_island_text_color_enabled",
                 "super_island_color_source",
+                "super_island_custom_color",
                 "super_island_share_enabled",
                 "super_island_share_format"
             ))

--- a/app/src/main/java/com/example/islandlyrics/feature/customsettings/CustomSettingsViewModel.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/customsettings/CustomSettingsViewModel.kt
@@ -108,7 +108,10 @@ class CustomSettingsViewModel(application: Application) : AndroidViewModel(appli
             is CustomSettingsAction.SetLiveUpdateTextLimit ->
                 prefs.edit { putFloat(LiveUpdateTextLimitConfig.KEY_CHARS, action.value) }
             is CustomSettingsAction.SetSuperIslandTextColorEnabled ->
-                prefs.edit { putBoolean(AppPreferences.Keys.SUPER_ISLAND_TEXT_COLOR_ENABLED, action.value) }
+                SuperIslandColorSource.write(
+                    prefs,
+                    if (action.value) SuperIslandColorSource.ALBUM_ART else SuperIslandColorSource.OFF
+                )
             is CustomSettingsAction.SetSuperIslandColorSource ->
                 SuperIslandColorSource.write(prefs, action.value)
             is CustomSettingsAction.SetSuperIslandCustomColor ->
@@ -174,6 +177,7 @@ class CustomSettingsViewModel(application: Application) : AndroidViewModel(appli
     private fun readState(): CustomSettingsUiState {
         val app = getApplication<Application>()
         LabFeatureManager.ensureInitialized(prefs)
+        val superIslandColorSource = SuperIslandColorSource.read(prefs)
         return CustomSettingsUiState(
             floatingLyricsLabEnabled = LabFeatureManager.isFloatingLyricsEnabled(prefs),
             followSystem = ThemeHelper.getFollowSystem(app),
@@ -205,8 +209,8 @@ class CustomSettingsViewModel(application: Application) : AndroidViewModel(appli
             capsuleRenderMode = CapsuleRenderMode.read(prefs),
             superIslandLyricMode = AppPreferences.superIslandLyricMode(prefs),
             superIslandFullLyricShowLeftCover = AppPreferences.isSuperIslandFullLyricLeftCoverEnabled(prefs),
-            superIslandTextColorEnabled = AppPreferences.isSuperIslandTextColorEnabled(prefs),
-            superIslandColorSource = SuperIslandColorSource.read(prefs),
+            superIslandTextColorEnabled = SuperIslandColorSource.isColorized(superIslandColorSource),
+            superIslandColorSource = superIslandColorSource,
             superIslandCustomColor = SuperIslandColorSource.readCustomColor(prefs),
             superIslandShareEnabled = AppPreferences.isSuperIslandShareEnabled(prefs),
             superIslandShareFormat = AppPreferences.superIslandShareFormat(prefs),

--- a/app/src/main/java/com/example/islandlyrics/feature/customsettings/material/CustomSettingsScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/customsettings/material/CustomSettingsScreen.kt
@@ -801,94 +801,80 @@ fun CustomSettingsScreen(
                                     }
 
                                     SettingsCardDivider()
-                                    SettingsSwitchItem(
-                                        title = stringResource(R.string.settings_super_island_colorize),
-                                        subtitle = stringResource(R.string.settings_super_island_colorize_desc),
-                                        checked = superIslandTextColorEnabled,
-                                        onCheckedChange = {
-                                            if (!it && superIslandColorEditing) {
+                                    val colorSources = SuperIslandColorSource.values
+                                    val colorSourceLabels = listOf(
+                                        stringResource(R.string.settings_super_island_color_source_off),
+                                        stringResource(R.string.settings_super_island_color_source_album_art),
+                                        stringResource(R.string.settings_super_island_color_source_album_art_readable_weak),
+                                        stringResource(R.string.settings_super_island_color_source_album_art_readable_strong),
+                                        stringResource(R.string.settings_super_island_color_source_custom)
+                                    )
+                                    val currentColorSourceIndex =
+                                        colorSources.indexOf(superIslandColorSource).takeIf { it >= 0 } ?: 0
+
+                                    Box(modifier = Modifier.fillMaxWidth()) {
+                                        SettingsTextItem(
+                                            title = stringResource(R.string.settings_super_island_colorize),
+                                            subtitle = stringResource(R.string.settings_super_island_colorize_desc),
+                                            value = colorSourceLabels[currentColorSourceIndex],
+                                            onClick = { showSuperIslandColorSourceDropdown = true }
+                                        )
+                                        Box(modifier = Modifier.matchParentSize().wrapContentSize(Alignment.Center)) {
+                                            MaterialBlurDropdownMenu(
+                                                expanded = showSuperIslandColorSourceDropdown,
+                                                onDismissRequest = { showSuperIslandColorSourceDropdown = false }
+                                            ) {
+                                                colorSourceLabels.forEachIndexed { index, label ->
+                                                    DropdownMenuItem(
+                                                        text = { Text(label) },
+                                                        onClick = {
+                                                            if (superIslandColorEditing) {
+                                                                superIslandCustomColor = superIslandColorSnapshot
+                                                                superIslandColorEditing = false
+                                                            }
+                                                            val newSource = colorSources[index]
+                                                            superIslandColorSource = newSource
+                                                            superIslandTextColorEnabled =
+                                                                SuperIslandColorSource.isColorized(newSource)
+                                                            viewModel.dispatch(CustomSettingsAction.SetSuperIslandColorSource(newSource))
+                                                            showSuperIslandColorSourceDropdown = false
+                                                        }
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    if (superIslandColorSource == SuperIslandColorSource.CUSTOM) {
+                                        SettingsCardDivider()
+                                        MaterialEditableColorSection(
+                                            title = stringResource(R.string.settings_super_island_custom_color),
+                                            color = superIslandCustomColor,
+                                            isEditing = superIslandColorEditing,
+                                            defaultActionText = stringResource(R.string.settings_color_default),
+                                            onStartEditing = {
+                                                superIslandColorSnapshot = superIslandCustomColor
+                                                superIslandColorEditing = true
+                                            },
+                                            onColorChanged = { color ->
+                                                superIslandCustomColor = color
+                                            },
+                                            onApply = {
+                                                viewModel.dispatch(CustomSettingsAction.SetSuperIslandCustomColor(superIslandCustomColor.toArgb()))
+                                                superIslandColorEditing = false
+                                            },
+                                            onCancel = {
                                                 superIslandCustomColor = superIslandColorSnapshot
                                                 superIslandColorEditing = false
+                                            },
+                                            onUseDefault = {
+                                                val defaultColor = Color(SuperIslandColorSource.DEFAULT_CUSTOM_COLOR)
+                                                superIslandCustomColor = defaultColor
+                                                superIslandColorSnapshot = defaultColor
+                                                viewModel.dispatch(CustomSettingsAction.SetSuperIslandCustomColor(defaultColor.toArgb()))
+                                                superIslandColorEditing = false
                                             }
-                                            superIslandTextColorEnabled = it
-                                            progressColorEnabled = it
-                                            viewModel.dispatch(CustomSettingsAction.SetSuperIslandTextColorEnabled(it))
-                                            viewModel.dispatch(CustomSettingsAction.SetProgressColorEnabled(it))
-                                        }
-                                    )
-
-                                    if (superIslandTextColorEnabled) {
-                                        val colorSources = SuperIslandColorSource.values
-                                        val colorSourceLabels = listOf(
-                                            stringResource(R.string.settings_super_island_color_source_album_art),
-                                            stringResource(R.string.settings_super_island_color_source_custom)
                                         )
-                                        val currentColorSourceIndex =
-                                            colorSources.indexOf(superIslandColorSource).takeIf { it >= 0 } ?: 0
-
-                                        SettingsCardDivider()
-                                        Box(modifier = Modifier.fillMaxWidth()) {
-                                            SettingsTextItem(
-                                                title = stringResource(R.string.settings_super_island_color_source),
-                                                subtitle = stringResource(R.string.settings_super_island_color_source_desc),
-                                                value = colorSourceLabels[currentColorSourceIndex],
-                                                onClick = { showSuperIslandColorSourceDropdown = true }
-                                            )
-                                            Box(modifier = Modifier.matchParentSize().wrapContentSize(Alignment.Center)) {
-                                                MaterialBlurDropdownMenu(
-                                                    expanded = showSuperIslandColorSourceDropdown,
-                                                    onDismissRequest = { showSuperIslandColorSourceDropdown = false }
-                                                ) {
-                                                    colorSourceLabels.forEachIndexed { index, label ->
-                                                        DropdownMenuItem(
-                                                            text = { Text(label) },
-                                                            onClick = {
-                                                                if (superIslandColorEditing) {
-                                                                    superIslandCustomColor = superIslandColorSnapshot
-                                                                    superIslandColorEditing = false
-                                                                }
-                                                                val newSource = colorSources[index]
-                                                                superIslandColorSource = newSource
-                                                                viewModel.dispatch(CustomSettingsAction.SetSuperIslandColorSource(newSource))
-                                                                showSuperIslandColorSourceDropdown = false
-                                                            }
-                                                        )
-                                                    }
-                                                }
-                                            }
-                                        }
-
-                                        if (superIslandColorSource == SuperIslandColorSource.CUSTOM) {
-                                            SettingsCardDivider()
-                                            MaterialEditableColorSection(
-                                                title = stringResource(R.string.settings_super_island_custom_color),
-                                                color = superIslandCustomColor,
-                                                isEditing = superIslandColorEditing,
-                                                defaultActionText = stringResource(R.string.settings_color_default),
-                                                onStartEditing = {
-                                                    superIslandColorSnapshot = superIslandCustomColor
-                                                    superIslandColorEditing = true
-                                                },
-                                                onColorChanged = { color ->
-                                                    superIslandCustomColor = color
-                                                },
-                                                onApply = {
-                                                    viewModel.dispatch(CustomSettingsAction.SetSuperIslandCustomColor(superIslandCustomColor.toArgb()))
-                                                    superIslandColorEditing = false
-                                                },
-                                                onCancel = {
-                                                    superIslandCustomColor = superIslandColorSnapshot
-                                                    superIslandColorEditing = false
-                                                },
-                                                onUseDefault = {
-                                                    val defaultColor = Color(SuperIslandColorSource.DEFAULT_CUSTOM_COLOR)
-                                                    superIslandCustomColor = defaultColor
-                                                    superIslandColorSnapshot = defaultColor
-                                                    viewModel.dispatch(CustomSettingsAction.SetSuperIslandCustomColor(defaultColor.toArgb()))
-                                                    superIslandColorEditing = false
-                                                }
-                                            )
-                                        }
                                     }
 
                                     SettingsCardDivider()
@@ -1047,6 +1033,8 @@ fun CustomSettingsScreen(
                                  actionStyle = effectiveActionStyle,
                                  superIslandEnabled = superIslandEnabled,
                                  superIslandTextColorEnabled = superIslandTextColorEnabled,
+                                 superIslandColorSource = superIslandColorSource,
+                                 superIslandCustomColor = superIslandCustomColor,
                                  superIslandMediaButtonLayout = superIslandMediaButtonLayout,
                                  superIslandNotificationStyle = superIslandNotificationStyle,
                                  superIslandLyricMode = superIslandLyricMode,

--- a/app/src/main/java/com/example/islandlyrics/feature/customsettings/miuix/MiuixCustomSettingsScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/customsettings/miuix/MiuixCustomSettingsScreen.kt
@@ -629,77 +629,64 @@ fun MiuixCustomSettingsScreen(
                                                 }
                                             }
 
-                                            SuperSwitch(
+                                            val colorSources = SuperIslandColorSource.values
+                                            val colorSourceLabels = listOf(
+                                                stringResource(R.string.settings_super_island_color_source_off),
+                                                stringResource(R.string.settings_super_island_color_source_album_art),
+                                                stringResource(R.string.settings_super_island_color_source_album_art_readable_weak),
+                                                stringResource(R.string.settings_super_island_color_source_album_art_readable_strong),
+                                                stringResource(R.string.settings_super_island_color_source_custom)
+                                            )
+                                            val currentColorSourceIndex =
+                                                colorSources.indexOf(superIslandColorSource).takeIf { it >= 0 } ?: 0
+
+                                            SuperDropdown(
                                                 title = stringResource(R.string.settings_super_island_colorize),
                                                 summary = stringResource(R.string.settings_super_island_colorize_desc),
-                                                checked = superIslandTextColorEnabled,
-                                                onCheckedChange = {
-                                                    if (!it && superIslandColorEditing) {
+                                                items = colorSourceLabels,
+                                                selectedIndex = currentColorSourceIndex,
+                                                onSelectedIndexChange = { index ->
+                                                    if (superIslandColorEditing) {
                                                         superIslandCustomColor = superIslandColorSnapshot
                                                         superIslandColorEditing = false
                                                     }
-                                                    superIslandTextColorEnabled = it
-                                                    progressColorEnabled = it
-                                                    viewModel.dispatch(CustomSettingsAction.SetSuperIslandTextColorEnabled(it))
-                                                    viewModel.dispatch(CustomSettingsAction.SetProgressColorEnabled(it))
+                                                    val newSource = colorSources[index]
+                                                    superIslandColorSource = newSource
+                                                    superIslandTextColorEnabled =
+                                                        SuperIslandColorSource.isColorized(newSource)
+                                                    viewModel.dispatch(CustomSettingsAction.SetSuperIslandColorSource(newSource))
                                                 }
                                             )
 
-                                            if (superIslandTextColorEnabled) {
-                                                val colorSources = SuperIslandColorSource.values
-                                                val colorSourceLabels = listOf(
-                                                    stringResource(R.string.settings_super_island_color_source_album_art),
-                                                    stringResource(R.string.settings_super_island_color_source_custom)
-                                                )
-                                                val currentColorSourceIndex =
-                                                    colorSources.indexOf(superIslandColorSource).takeIf { it >= 0 } ?: 0
-
-                                                SuperDropdown(
-                                                    title = stringResource(R.string.settings_super_island_color_source),
-                                                    summary = stringResource(R.string.settings_super_island_color_source_desc),
-                                                    items = colorSourceLabels,
-                                                    selectedIndex = currentColorSourceIndex,
-                                                    onSelectedIndexChange = { index ->
-                                                        if (superIslandColorEditing) {
-                                                            superIslandCustomColor = superIslandColorSnapshot
-                                                            superIslandColorEditing = false
-                                                        }
-                                                        val newSource = colorSources[index]
-                                                        superIslandColorSource = newSource
-                                                        viewModel.dispatch(CustomSettingsAction.SetSuperIslandColorSource(newSource))
+                                            if (superIslandColorSource == SuperIslandColorSource.CUSTOM) {
+                                                MiuixEditableColorSection(
+                                                    title = stringResource(R.string.settings_super_island_custom_color),
+                                                    color = superIslandCustomColor,
+                                                    isEditing = superIslandColorEditing,
+                                                    defaultActionText = stringResource(R.string.settings_color_default),
+                                                    onStartEditing = {
+                                                        superIslandColorSnapshot = superIslandCustomColor
+                                                        superIslandColorEditing = true
+                                                    },
+                                                    onColorChanged = { color ->
+                                                        superIslandCustomColor = color
+                                                    },
+                                                    onApply = {
+                                                        viewModel.dispatch(CustomSettingsAction.SetSuperIslandCustomColor(superIslandCustomColor.toArgb()))
+                                                        superIslandColorEditing = false
+                                                    },
+                                                    onCancel = {
+                                                        superIslandCustomColor = superIslandColorSnapshot
+                                                        superIslandColorEditing = false
+                                                    },
+                                                    onUseDefault = {
+                                                        val defaultColor = Color(SuperIslandColorSource.DEFAULT_CUSTOM_COLOR)
+                                                        superIslandCustomColor = defaultColor
+                                                        superIslandColorSnapshot = defaultColor
+                                                        viewModel.dispatch(CustomSettingsAction.SetSuperIslandCustomColor(defaultColor.toArgb()))
+                                                        superIslandColorEditing = false
                                                     }
                                                 )
-
-                                                if (superIslandColorSource == SuperIslandColorSource.CUSTOM) {
-                                                    MiuixEditableColorSection(
-                                                        title = stringResource(R.string.settings_super_island_custom_color),
-                                                        color = superIslandCustomColor,
-                                                        isEditing = superIslandColorEditing,
-                                                        defaultActionText = stringResource(R.string.settings_color_default),
-                                                        onStartEditing = {
-                                                            superIslandColorSnapshot = superIslandCustomColor
-                                                            superIslandColorEditing = true
-                                                        },
-                                                        onColorChanged = { color ->
-                                                            superIslandCustomColor = color
-                                                        },
-                                                        onApply = {
-                                                            viewModel.dispatch(CustomSettingsAction.SetSuperIslandCustomColor(superIslandCustomColor.toArgb()))
-                                                            superIslandColorEditing = false
-                                                        },
-                                                        onCancel = {
-                                                            superIslandCustomColor = superIslandColorSnapshot
-                                                            superIslandColorEditing = false
-                                                        },
-                                                        onUseDefault = {
-                                                            val defaultColor = Color(SuperIslandColorSource.DEFAULT_CUSTOM_COLOR)
-                                                            superIslandCustomColor = defaultColor
-                                                            superIslandColorSnapshot = defaultColor
-                                                            viewModel.dispatch(CustomSettingsAction.SetSuperIslandCustomColor(defaultColor.toArgb()))
-                                                            superIslandColorEditing = false
-                                                        }
-                                                    )
-                                                }
                                             }
 
                                             SuperSwitch(
@@ -837,9 +824,11 @@ fun MiuixCustomSettingsScreen(
                                 NotificationPreview(
                                     progressColorEnabled = progressColorEnabled,
                                     actionStyle = effectiveActionStyle,
-                                    superIslandEnabled = superIslandEnabled,
-                                    superIslandTextColorEnabled = superIslandTextColorEnabled,
-                                    superIslandMediaButtonLayout = superIslandMediaButtonLayout,
+                                     superIslandEnabled = superIslandEnabled,
+                                     superIslandTextColorEnabled = superIslandTextColorEnabled,
+                                     superIslandColorSource = superIslandColorSource,
+                                     superIslandCustomColor = superIslandCustomColor,
+                                     superIslandMediaButtonLayout = superIslandMediaButtonLayout,
                                     superIslandNotificationStyle = superIslandNotificationStyle,
                                     superIslandLyricMode = superIslandLyricMode,
                                     superIslandFullLyricShowLeftCover = superIslandFullLyricShowLeftCover,

--- a/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/SuperIslandHandler.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/SuperIslandHandler.kt
@@ -190,6 +190,7 @@ class SuperIslandHandler(
             displayLyric = displayLyric,
             progressPercent = progressPercent,
             accentColor = accentColor,
+            colorMode = preferences.colorSource,
             extraContentSignature = dualLineText?.signature.orEmpty()
         ) ?: return
 
@@ -213,9 +214,9 @@ class SuperIslandHandler(
         )
 
         val hexColor = String.format("#FF%06X", 0xFFFFFF and accentColor)
-        val showHighlightColor = preferences.textColorEnabled 
+        val showHighlightColor = SuperIslandColorSource.isColorized(preferences.colorSource)
         val ringColor = if (showHighlightColor) hexColor else "#757575"
-        val progressBarColor = if (preferences.progressBarColorEnabled) hexColor else "#757575"
+        val progressBarColor = if (showHighlightColor) hexColor else "#757575"
         val packageName = state.mediaPackage.ifEmpty { context.packageName }
         val titleWithArtist = if (state.artist.isNotBlank()) "${state.title} - ${state.artist}" else state.title
         val template2Icon = resolveTemplate2Icon()
@@ -296,6 +297,7 @@ class SuperIslandHandler(
             progressPercent = progressPercent,
             subText = subText,
             accentColor = accentColor,
+            colorMode = preferences.colorSource,
             extraContentSignature = dualLineText?.signature.orEmpty(),
             focusSignature = focusSignature
         )

--- a/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/config/SuperIslandColorSource.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/config/SuperIslandColorSource.kt
@@ -79,8 +79,16 @@ object SuperIslandColorSource {
     fun resolveColor(source: String, albumColor: Int, customColor: Int): Int {
         return when (source) {
             ALBUM_ART -> albumColor
-            ALBUM_ART_READABLE_WEAK -> ensureReadable(albumColor, WEAK_MINIMUM_CONTRAST)
-            ALBUM_ART_READABLE_STRONG -> ensureReadable(albumColor, STRONG_MINIMUM_CONTRAST)
+            ALBUM_ART_READABLE_WEAK -> ensureReadable(
+                color = albumColor,
+                minimumContrast = WEAK_MINIMUM_CONTRAST,
+                minimumWhiteRatio = WEAK_WHITE_RATIO
+            )
+            ALBUM_ART_READABLE_STRONG -> ensureReadable(
+                color = albumColor,
+                minimumContrast = STRONG_MINIMUM_CONTRAST,
+                minimumWhiteRatio = STRONG_WHITE_RATIO
+            )
             CUSTOM -> customColor
             else -> DEFAULT_NEUTRAL_COLOR
         }
@@ -89,10 +97,15 @@ object SuperIslandColorSource {
     private fun isLegacyEnabled(prefs: SharedPreferences): Boolean =
         prefs.getBoolean(AppPreferences.Keys.SUPER_ISLAND_TEXT_COLOR_ENABLED, false)
 
-    private fun ensureReadable(color: Int, minimumContrast: Double): Int {
-        if (ColorUtils.calculateContrast(color, Color.BLACK) >= minimumContrast) return color
+    private fun ensureReadable(
+        color: Int,
+        minimumContrast: Double,
+        minimumWhiteRatio: Float
+    ): Int {
+        val baseColor = ColorUtils.blendARGB(color, Color.WHITE, minimumWhiteRatio)
+        if (ColorUtils.calculateContrast(baseColor, Color.BLACK) >= minimumContrast) return baseColor
 
-        var low = 0f
+        var low = minimumWhiteRatio
         var high = 1f
         repeat(20) {
             val ratio = (low + high) / 2f
@@ -108,4 +121,6 @@ object SuperIslandColorSource {
 
     private const val WEAK_MINIMUM_CONTRAST = 3.0
     private const val STRONG_MINIMUM_CONTRAST = 4.5
+    private const val WEAK_WHITE_RATIO = 0.20f
+    private const val STRONG_WHITE_RATIO = 0.70f
 }

--- a/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/config/SuperIslandColorSource.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/config/SuperIslandColorSource.kt
@@ -21,27 +21,49 @@
  */
 
 package com.example.islandlyrics.ui.overlay.superisland.config
+
+import android.graphics.Color
 import android.content.SharedPreferences
+import androidx.core.graphics.ColorUtils
+import com.example.islandlyrics.core.settings.AppPreferences
 
 object SuperIslandColorSource {
     const val PREF_KEY = "super_island_color_source"
     const val CUSTOM_COLOR_PREF_KEY = "super_island_custom_color"
 
+    const val OFF = "off"
     const val ALBUM_ART = "album_art"
+    const val ALBUM_ART_READABLE_WEAK = "album_art_readable_weak"
+    const val ALBUM_ART_READABLE_STRONG = "album_art_readable_strong"
     const val CUSTOM = "custom"
 
     const val DEFAULT_CUSTOM_COLOR = 0xFF3482FF.toInt()
+    const val DEFAULT_NEUTRAL_COLOR = 0xFF757575.toInt()
 
-    val values = listOf(ALBUM_ART, CUSTOM)
+    val values = listOf(
+        OFF,
+        ALBUM_ART,
+        ALBUM_ART_READABLE_WEAK,
+        ALBUM_ART_READABLE_STRONG,
+        CUSTOM
+    )
 
     fun read(prefs: SharedPreferences): String {
-        return prefs.getString(PREF_KEY, ALBUM_ART)
-            ?.takeIf { it in values }
-            ?: ALBUM_ART
+        val source = prefs.getString(PREF_KEY, null)
+        return when (source) {
+            OFF, ALBUM_ART_READABLE_WEAK, ALBUM_ART_READABLE_STRONG -> source
+            ALBUM_ART, CUSTOM -> if (isLegacyEnabled(prefs)) source else OFF
+            null -> if (isLegacyEnabled(prefs)) ALBUM_ART else OFF
+            else -> if (isLegacyEnabled(prefs)) ALBUM_ART else OFF
+        }
     }
 
     fun write(prefs: SharedPreferences, source: String) {
-        prefs.edit().putString(PREF_KEY, source.takeIf { it in values } ?: ALBUM_ART).apply()
+        val normalizedSource = source.takeIf { it in values } ?: OFF
+        prefs.edit()
+            .putString(PREF_KEY, normalizedSource)
+            .putBoolean(AppPreferences.Keys.SUPER_ISLAND_TEXT_COLOR_ENABLED, normalizedSource != OFF)
+            .apply()
     }
 
     fun readCustomColor(prefs: SharedPreferences): Int {
@@ -52,7 +74,38 @@ object SuperIslandColorSource {
         prefs.edit().putInt(CUSTOM_COLOR_PREF_KEY, color).apply()
     }
 
+    fun isColorized(source: String): Boolean = source != OFF
+
     fun resolveColor(source: String, albumColor: Int, customColor: Int): Int {
-        return if (source == CUSTOM) customColor else albumColor
+        return when (source) {
+            ALBUM_ART -> albumColor
+            ALBUM_ART_READABLE_WEAK -> ensureReadable(albumColor, WEAK_MINIMUM_CONTRAST)
+            ALBUM_ART_READABLE_STRONG -> ensureReadable(albumColor, STRONG_MINIMUM_CONTRAST)
+            CUSTOM -> customColor
+            else -> DEFAULT_NEUTRAL_COLOR
+        }
     }
+
+    private fun isLegacyEnabled(prefs: SharedPreferences): Boolean =
+        prefs.getBoolean(AppPreferences.Keys.SUPER_ISLAND_TEXT_COLOR_ENABLED, false)
+
+    private fun ensureReadable(color: Int, minimumContrast: Double): Int {
+        if (ColorUtils.calculateContrast(color, Color.BLACK) >= minimumContrast) return color
+
+        var low = 0f
+        var high = 1f
+        repeat(20) {
+            val ratio = (low + high) / 2f
+            val candidate = ColorUtils.blendARGB(color, Color.WHITE, ratio)
+            if (ColorUtils.calculateContrast(candidate, Color.BLACK) >= minimumContrast) {
+                high = ratio
+            } else {
+                low = ratio
+            }
+        }
+        return ColorUtils.blendARGB(color, Color.WHITE, high)
+    }
+
+    private const val WEAK_MINIMUM_CONTRAST = 3.0
+    private const val STRONG_MINIMUM_CONTRAST = 4.5
 }

--- a/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/config/SuperIslandPreferencesCache.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/config/SuperIslandPreferencesCache.kt
@@ -62,7 +62,7 @@ internal class SuperIslandPreferencesCache(
         private set
     var fullLyricShowLeftCover = true
         private set
-    var colorSource = SuperIslandColorSource.ALBUM_ART
+    var colorSource = SuperIslandColorSource.OFF
         private set
     var customColor = 0xFF3482FF.toInt()
         private set
@@ -86,9 +86,14 @@ internal class SuperIslandPreferencesCache(
                 clickStyle = AppPreferences.notificationClickStyle(p)
                 onClickStyleChanged()
             }
-            AppPreferences.Keys.SUPER_ISLAND_TEXT_COLOR_ENABLED ->
-                textColorEnabled = AppPreferences.isSuperIslandTextColorEnabled(p)
-            SuperIslandColorSource.PREF_KEY -> colorSource = SuperIslandColorSource.read(p)
+            AppPreferences.Keys.SUPER_ISLAND_TEXT_COLOR_ENABLED -> {
+                colorSource = SuperIslandColorSource.read(p)
+                textColorEnabled = SuperIslandColorSource.isColorized(colorSource)
+            }
+            SuperIslandColorSource.PREF_KEY -> {
+                colorSource = SuperIslandColorSource.read(p)
+                textColorEnabled = SuperIslandColorSource.isColorized(colorSource)
+            }
             SuperIslandColorSource.CUSTOM_COLOR_PREF_KEY -> customColor = SuperIslandColorSource.readCustomColor(p)
             AppPreferences.Keys.SUPER_ISLAND_SHARE_ENABLED ->
                 shareEnabled = AppPreferences.isSuperIslandShareEnabled(p)
@@ -141,8 +146,8 @@ internal class SuperIslandPreferencesCache(
 
     private fun load() {
         clickStyle = AppPreferences.notificationClickStyle(prefs)
-        textColorEnabled = AppPreferences.isSuperIslandTextColorEnabled(prefs)
         colorSource = SuperIslandColorSource.read(prefs)
+        textColorEnabled = SuperIslandColorSource.isColorized(colorSource)
         customColor = SuperIslandColorSource.readCustomColor(prefs)
         shareEnabled = AppPreferences.isSuperIslandShareEnabled(prefs)
         shareFormat = AppPreferences.superIslandShareFormat(prefs)

--- a/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/state/SuperIslandRenderStateTracker.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/state/SuperIslandRenderStateTracker.kt
@@ -47,6 +47,7 @@ internal class SuperIslandRenderStateTracker {
     private var lastFocusParam = ""
     private var lastNotifyTime = 0L
     private var lastAppliedAlbumColor = 0
+    private var lastAppliedColorMode = ""
 
     fun resetForStart() {
         lastSentDisplayLyric = ""
@@ -60,6 +61,7 @@ internal class SuperIslandRenderStateTracker {
         isFirstNotification = true
         firstNotificationReason = "initial"
         lastAppliedAlbumColor = 0
+        lastAppliedColorMode = ""
         lastFocusParam = ""
     }
 
@@ -72,6 +74,7 @@ internal class SuperIslandRenderStateTracker {
         displayLyric: String,
         progressPercent: Int,
         accentColor: Int,
+        colorMode: String = "",
         extraContentSignature: String = ""
     ): SuperIslandRenderDecision? {
         val trackChanged = state.title != lastSentTitle || state.artist != lastSentArtist
@@ -88,7 +91,7 @@ internal class SuperIslandRenderStateTracker {
             lastFocusParam = ""
         }
 
-        val colorChanged = accentColor != lastAppliedAlbumColor
+        val colorChanged = accentColor != lastAppliedAlbumColor || colorMode != lastAppliedColorMode
 
         val lyricLineChanged = !isFirstNotification && !trackChanged
                 && state.fullLyric.isNotEmpty() && state.fullLyric != lastSentFullLyric
@@ -135,10 +138,12 @@ internal class SuperIslandRenderStateTracker {
         progressPercent: Int,
         subText: String,
         accentColor: Int,
+        colorMode: String = "",
         extraContentSignature: String = "",
         focusSignature: String
     ) {
         lastAppliedAlbumColor = accentColor
+        lastAppliedColorMode = colorMode
         lastFocusParam = focusSignature
         lastSentDisplayLyric = displayLyric
         lastSentFullLyric = state.fullLyric

--- a/app/src/main/java/com/example/islandlyrics/ui/preview/SettingsPreviewUtils.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/preview/SettingsPreviewUtils.kt
@@ -125,11 +125,14 @@ fun CapsulePreview(
         )
     )
     
-    val superIslandAccentColor = if (superIslandColorSource == SuperIslandColorSource.CUSTOM) {
-        superIslandCustomColor
-    } else {
-        extractedColor ?: Color(0xFF3482FF)
-    }
+    val superIslandAccentColor = Color(
+        SuperIslandColorSource.resolveColor(
+            source = superIslandColorSource,
+            albumColor = previewAlbumColor,
+            customColor = superIslandCustomColor.toArgb()
+        )
+    )
+    val superIslandColorized = SuperIslandColorSource.isColorized(superIslandColorSource)
 
     if (superIslandEnabled) {
         val showLeftCover = albumArt != null &&
@@ -179,7 +182,7 @@ fun CapsulePreview(
                 }
                 Text(
                     text = leftText,
-                    color = if (superIslandTextColorEnabled) superIslandAccentColor else Color.White,
+                    color = if (superIslandColorized) superIslandAccentColor else Color.White,
                     fontWeight = FontWeight.Bold,
                     fontSize = 14.sp,
                     maxLines = 1,
@@ -189,7 +192,7 @@ fun CapsulePreview(
                 Spacer(modifier = Modifier.width(14.dp))
                 Text(
                     text = rightText,
-                    color = if (superIslandTextColorEnabled) superIslandAccentColor else Color.White,
+                    color = if (superIslandColorized) superIslandAccentColor else Color.White,
                     fontWeight = FontWeight.Bold,
                     fontSize = 14.sp,
                     maxLines = 1,
@@ -319,6 +322,8 @@ fun NotificationPreview(
     actionStyle: String,
     superIslandEnabled: Boolean = false,
     superIslandTextColorEnabled: Boolean = false,
+    superIslandColorSource: String = SuperIslandColorSource.OFF,
+    superIslandCustomColor: Color = Color(0xFF3482FF),
     superIslandMediaButtonLayout: String = "two_button",
     superIslandNotificationStyle: String = "standard",
     superIslandLyricMode: String = "standard",
@@ -395,8 +400,24 @@ fun NotificationPreview(
     }
     
     val barColor = if (progressColorEnabled && extractedColor != null) extractedColor!! else MaterialTheme.colorScheme.primary
-    val textColor = if (superIslandTextColorEnabled && extractedColor != null) extractedColor!! else Color.White
-    val secondaryTextColor = if (superIslandTextColorEnabled && extractedColor != null) extractedColor!!.copy(alpha = 0.8f) else Color(0xFFB0B0B0)
+    val superIslandAccentColor = Color(
+        SuperIslandColorSource.resolveColor(
+            source = superIslandColorSource,
+            albumColor = extractedColor?.toArgb() ?: SuperIslandColorSource.DEFAULT_CUSTOM_COLOR,
+            customColor = superIslandCustomColor.toArgb()
+        )
+    )
+    val superIslandColorized = SuperIslandColorSource.isColorized(superIslandColorSource)
+    val textColor = when {
+        superIslandEnabled && superIslandColorized -> superIslandAccentColor
+        !superIslandEnabled && superIslandTextColorEnabled && extractedColor != null -> extractedColor!!
+        else -> Color.White
+    }
+    val secondaryTextColor = when {
+        superIslandEnabled && superIslandColorized -> superIslandAccentColor.copy(alpha = 0.8f)
+        !superIslandEnabled && superIslandTextColorEnabled && extractedColor != null -> extractedColor!!.copy(alpha = 0.8f)
+        else -> Color(0xFFB0B0B0)
+    }
 
     if (superIslandEnabled) {
         // Premium Super Island Style Notification Preview
@@ -493,7 +514,7 @@ fun NotificationPreview(
                             CircularProgressIndicator(
                                 progress = { progress },
                                 strokeWidth = 3.dp,
-                                color = if (progressColorEnabled) barColor else Color.White,
+                                color = if (superIslandColorized) superIslandAccentColor else Color.White,
                                 trackColor = if (showAdvancedStyle) Color.White.copy(alpha = 0.18f) else Color.Transparent,
                                 modifier = Modifier.fillMaxSize()
                             )
@@ -723,8 +744,8 @@ fun NotificationPreview(
                                 .fillMaxWidth()
                                 .height(4.dp)
                                 .clip(RoundedCornerShape(2.dp)),
-                            color = if (progressColorEnabled) barColor else Color.Gray.copy(alpha = 0.6f),
-                            trackColor = if (progressColorEnabled) barColor.copy(alpha = 0.2f) else Color(0xFF1A2633)
+                            color = if (superIslandColorized) superIslandAccentColor else Color.Gray.copy(alpha = 0.6f),
+                            trackColor = if (superIslandColorized) superIslandAccentColor.copy(alpha = 0.2f) else Color(0xFF1A2633)
                         )
                     }
                 }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -750,10 +750,13 @@
     <string name="settings_super_island_left_text_limit">左侧歌词字数上限</string>
     <string name="settings_live_update_text_limit">Live Update 歌词字数上限</string>
     <string name="settings_super_island_colorize">为胶囊内容着色</string>
-    <string name="settings_super_island_colorize_desc">为超级岛中的歌词、播放信息、胶囊边缘和进度条着色。</string>
+    <string name="settings_super_island_colorize_desc">选择超级岛歌词、播放信息、边缘/进度环和进度条的着色方式。</string>
     <string name="settings_super_island_color_source">取色来源</string>
-    <string name="settings_super_island_color_source_desc">选择胶囊颜色使用专辑封面取色还是自定义取色。</string>
-    <string name="settings_super_island_color_source_album_art">专辑封面取色</string>
+    <string name="settings_super_island_color_source_desc">选择超级岛内容的颜色模式。</string>
+    <string name="settings_super_island_color_source_off">关闭</string>
+    <string name="settings_super_island_color_source_album_art">专辑封面取色（原色）</string>
+    <string name="settings_super_island_color_source_album_art_readable_weak">专辑封面取色（可读性增强·弱）</string>
+    <string name="settings_super_island_color_source_album_art_readable_strong">专辑封面取色（可读性增强·强）</string>
     <string name="settings_super_island_color_source_custom">自定义取色</string>
     <string name="settings_super_island_custom_color">胶囊自定义颜色</string>
     <string name="settings_super_island_share">开启拖拽分享</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -412,10 +412,13 @@
     <string name="ui_style_miuix">Miuix</string>
     <string name="settings_disable_scrolling_desc">Displays static text only. Prevents ALL scrolling, regardless of lyric type.</string>
     <string name="settings_super_island_colorize">Colorize Capsule Content</string>
-    <string name="settings_super_island_colorize_desc">Apply color to Super Island lyrics, playback info, capsule edge, and progress bar.</string>
+    <string name="settings_super_island_colorize_desc">Choose how Super Island lyrics, playback info, capsule edge, and progress bar are colored.</string>
     <string name="settings_super_island_color_source">Color Source</string>
-    <string name="settings_super_island_color_source_desc">Choose whether capsule colors come from album art or a custom color.</string>
-    <string name="settings_super_island_color_source_album_art">Album Art Color</string>
+    <string name="settings_super_island_color_source_desc">Choose a color mode for Super Island content.</string>
+    <string name="settings_super_island_color_source_off">Off</string>
+    <string name="settings_super_island_color_source_album_art">Album Art Color (Original)</string>
+    <string name="settings_super_island_color_source_album_art_readable_weak">Album Art Color (Readability Boost · Light)</string>
+    <string name="settings_super_island_color_source_album_art_readable_strong">Album Art Color (Readability Boost · Strong)</string>
     <string name="settings_super_island_color_source_custom">Custom Color</string>
     <string name="settings_super_island_custom_color">Capsule Custom Color</string>
     <string name="settings_super_island_share">Enable Drag-and-Drop Sharing</string>


### PR DESCRIPTION
 针对深色专辑封面导致歌词可读性较差的问题， 新增原色、可读性增强（弱）、可读性增强（强）和自定义颜色模式。 其中原色模式保持旧版本取色效果，弱/强模式用于提升颜色对比度。