### PR TITLE
fix: 修复标准小米超级岛歌词滚动、左右字号不一致及摄像头遮挡问题

### DIFF
--- a/app/src/main/java/com/example/islandlyrics/feature/customsettings/material/CustomSettingsScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/customsettings/material/CustomSettingsScreen.kt
@@ -334,7 +334,10 @@ fun CustomSettingsScreen(
         actionStyle
     }
     val forceDisableScrollingForSuperIslandLyricMode =
-        islandStyleCapsuleEnabled && superIslandLyricMode == "full"
+        islandStyleCapsuleEnabled &&
+            superIslandLyricMode == "full" &&
+            (superIslandNotificationStyle == LabFeatureManager.SUPER_ISLAND_STYLE_ADVANCED ||
+                superIslandNotificationStyle == LabFeatureManager.SUPER_ISLAND_STYLE_ADVANCED_LYRICS_DUAL)
 
     fun applySuperIslandScrollForce(force: Boolean, restoreLegacyState: Boolean = false) {
         val currentDisableScrolling = disableScrolling

--- a/app/src/main/java/com/example/islandlyrics/feature/customsettings/miuix/MiuixCustomSettingsScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/customsettings/miuix/MiuixCustomSettingsScreen.kt
@@ -310,7 +310,10 @@ fun MiuixCustomSettingsScreen(
         actionStyle
     }
     val forceDisableScrollingForSuperIslandLyricMode =
-        islandStyleCapsuleEnabled && superIslandLyricMode == "full"
+        islandStyleCapsuleEnabled &&
+            superIslandLyricMode == "full" &&
+            (superIslandNotificationStyle == LabFeatureManager.SUPER_ISLAND_STYLE_ADVANCED ||
+                superIslandNotificationStyle == LabFeatureManager.SUPER_ISLAND_STYLE_ADVANCED_LYRICS_DUAL)
 
     fun applySuperIslandScrollForce(force: Boolean, restoreLegacyState: Boolean = false) {
         val currentDisableScrolling = disableScrolling

--- a/app/src/main/java/com/example/islandlyrics/ui/overlay/display/LyricDisplayManager.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/overlay/display/LyricDisplayManager.kt
@@ -42,6 +42,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.lifecycle.Observer
+import kotlin.math.roundToInt
 
 /**
  * LyricDisplayManager
@@ -131,8 +132,12 @@ class LyricDisplayManager(private val context: Context) {
             LyricTextDisplayMode.PREF_KEY,
             CapsuleRenderMode.PREF_KEY,
             AppPreferences.Keys.SUPER_ISLAND_ENABLED_LEGACY,
+            AppPreferences.Keys.SUPER_ISLAND_NOTIFICATION_STYLE,
             AppPreferences.Keys.SUPER_ISLAND_LYRIC_MODE,
+            AppPreferences.Keys.SUPER_ISLAND_FULL_LYRIC_SHOW_LEFT_COVER,
             SuperIslandTextLimitConfig.KEY_RIGHT_CHARS,
+            SuperIslandTextLimitConfig.KEY_LEFT_WITH_COVER_CHARS,
+            SuperIslandTextLimitConfig.KEY_LEFT_NO_COVER_CHARS,
             OverlayDisplayConfig.KEY_SUPER_ISLAND_RELAXED_TEXT_LIMITS,
             LabFeatureManager.KEY_LIVE_UPDATE_TEXT_LIMITS_ENABLED,
             LiveUpdateTextLimitConfig.KEY_CHARS -> {
@@ -324,7 +329,20 @@ class LyricDisplayManager(private val context: Context) {
             val currentLine = effectiveParsedLyricState.currentLine(currentPosition)
             if (currentLine != null && !currentLine.syllables.isNullOrEmpty()) {
                 val text = resolvePreferredLineText(currentLine.text, lyricInfo, currentLine)
-                displayLyric = if (text == currentLine.text) {
+                val totalWeight = LyricTextWindowCalculator.weight(text)
+                val timedLineDisplay = if (displayConfig.standardFullLyricScrollingEnabled) {
+                    calculateTimedLineScroll(
+                        text = text,
+                        totalWeight = totalWeight,
+                        startTime = currentLine.startTime,
+                        endTime = currentLine.endTime,
+                        position = currentPosition,
+                        maxDisplayWeight = maxDisplayWeight
+                    )
+                } else {
+                    null
+                }
+                displayLyric = timedLineDisplay ?: if (text == currentLine.text) {
                     val sungSyllables = currentLine.syllables.filter { it.startTime <= currentPosition }
                     LyricTextWindowCalculator.syllableWindow(
                         fullText = currentLine.text,
@@ -360,15 +378,29 @@ class LyricDisplayManager(private val context: Context) {
             if (foundLine != null) {
                 val preferredLineText = resolvePreferredLineText(foundLine.text, lyricInfo, foundLine)
                 fullLyricForDisplay = preferredLineText
-                val lineDuration = foundLine.endTime - foundLine.startTime
-                val lineProgress = if (lineDuration > 0) {
-                    ((currentPosition - foundLine.startTime).toFloat() / lineDuration.toFloat()).coerceIn(0f, 1f)
-                } else 0f
                 val currentLineWeight = LyricTextWindowCalculator.weight(preferredLineText)
-                
-                if (currentLineWeight <= maxDisplayWeight) {
+                val timedLineDisplay = if (displayConfig.standardFullLyricScrollingEnabled) {
+                    calculateTimedLineScroll(
+                        text = preferredLineText,
+                        totalWeight = currentLineWeight,
+                        startTime = foundLine.startTime,
+                        endTime = foundLine.endTime,
+                        position = currentPosition,
+                        maxDisplayWeight = maxDisplayWeight
+                    )
+                } else {
+                    null
+                }
+
+                if (timedLineDisplay != null) {
+                    displayLyric = timedLineDisplay
+                } else if (currentLineWeight <= maxDisplayWeight) {
                     displayLyric = preferredLineText
                 } else {
+                    val lineDuration = foundLine.endTime - foundLine.startTime
+                    val lineProgress = if (lineDuration > 0) {
+                        ((currentPosition - foundLine.startTime).toFloat() / lineDuration.toFloat()).coerceIn(0f, 1f)
+                    } else 0f
                     val currentProgressWeight = (lineProgress * currentLineWeight).toInt()
                     val scrollStartThreshold = LyricTextWindowCalculator.scrollStartThreshold(preferredLineText, maxDisplayWeight)
                     val targetWeightOffset = if (currentProgressWeight < scrollStartThreshold) 0 else currentProgressWeight - scrollStartThreshold
@@ -649,6 +681,24 @@ class LyricDisplayManager(private val context: Context) {
 
     private fun currentMaxDisplayWeight(): Int {
         return displayConfig.maxDisplayWeight(baseMaxDisplayWeight)
+    }
+
+    private fun calculateTimedLineScroll(
+        text: String,
+        totalWeight: Int,
+        startTime: Long,
+        endTime: Long,
+        position: Long,
+        maxDisplayWeight: Int
+    ): String? {
+        val duration = endTime - startTime
+        if (duration <= 0L) return null
+        if (totalWeight <= maxDisplayWeight) return text
+
+        val progress = ((position - startTime).toDouble() / duration.toDouble()).coerceIn(0.0, 1.0)
+        val scrollDistance = totalWeight - maxDisplayWeight
+        val offset = (scrollDistance * progress).roundToInt()
+        return LyricTextWindowCalculator.extractByWeight(text, offset, maxDisplayWeight)
     }
 
     private fun resolveTimingGapDisplay(

--- a/app/src/main/java/com/example/islandlyrics/ui/overlay/display/OverlayDisplayConfig.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/overlay/display/OverlayDisplayConfig.kt
@@ -34,15 +34,24 @@ internal data class OverlayDisplayConfig(
     val disableScrolling: Boolean,
     val lyricTextDisplayMode: String,
     val capsuleRenderMode: CapsuleRenderMode,
+    val superIslandNotificationStyle: String,
     val superIslandLyricMode: String,
     val superIslandRightTextWeight: Int,
+    val superIslandFullLyricTextWeight: Int,
     val liveUpdateTextLimitsEnabled: Boolean,
     val liveUpdateTextWeight: Int
 ) {
+    val standardFullLyricScrollingEnabled: Boolean
+        get() = RomUtils.isHyperOs() &&
+            capsuleRenderMode == CapsuleRenderMode.XIAOMI_SUPER_ISLAND &&
+            superIslandNotificationStyle == LabFeatureManager.SUPER_ISLAND_STYLE_STANDARD &&
+            superIslandLyricMode == "full"
+
     fun maxDisplayWeight(baseMaxDisplayWeight: Int): Int {
         return when {
             capsuleRenderMode == CapsuleRenderMode.LIVE_UPDATE ->
                 if (liveUpdateTextLimitsEnabled) liveUpdateTextWeight else LiveUpdateTextLimitConfig.defaultWeight()
+            standardFullLyricScrollingEnabled -> superIslandFullLyricTextWeight
             RomUtils.isHyperOs() &&
                 capsuleRenderMode == CapsuleRenderMode.XIAOMI_SUPER_ISLAND &&
                 superIslandLyricMode == "standard" -> superIslandRightTextWeight
@@ -56,17 +65,28 @@ internal data class OverlayDisplayConfig(
 
         fun from(prefs: SharedPreferences): OverlayDisplayConfig {
             val relaxedLimitsEnabled = prefs.getBoolean(KEY_SUPER_ISLAND_RELAXED_TEXT_LIMITS, false)
+            val superIslandRightTextWeight = SuperIslandTextLimitConfig.weightForChars(
+                SuperIslandTextLimitConfig.rightChars(
+                    prefs = prefs,
+                    relaxed = relaxedLimitsEnabled
+                )
+            )
+            val superIslandFullLyricLeftTextWeight = SuperIslandTextLimitConfig.weightForChars(
+                SuperIslandTextLimitConfig.leftChars(
+                    prefs = prefs,
+                    showLeftCover = AppPreferences.isSuperIslandFullLyricLeftCoverEnabled(prefs),
+                    relaxed = relaxedLimitsEnabled
+                )
+            )
             return OverlayDisplayConfig(
                 disableScrolling = AppPreferences.isLyricScrollingDisabled(prefs),
                 lyricTextDisplayMode = LyricTextDisplayMode.read(prefs),
                 capsuleRenderMode = CapsuleRenderMode.effective(prefs),
+                superIslandNotificationStyle = AppPreferences.superIslandNotificationStyle(prefs),
                 superIslandLyricMode = AppPreferences.superIslandLyricMode(prefs),
-                superIslandRightTextWeight = SuperIslandTextLimitConfig.weightForChars(
-                    SuperIslandTextLimitConfig.rightChars(
-                        prefs = prefs,
-                        relaxed = relaxedLimitsEnabled
-                    )
-                ),
+                superIslandRightTextWeight = superIslandRightTextWeight,
+                superIslandFullLyricTextWeight =
+                    superIslandFullLyricLeftTextWeight + superIslandRightTextWeight,
                 liveUpdateTextLimitsEnabled = LabFeatureManager.isLiveUpdateTextLimitsEnabled(prefs),
                 liveUpdateTextWeight = LiveUpdateTextLimitConfig.weightForChars(
                     LiveUpdateTextLimitConfig.chars(prefs)

--- a/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/config/SuperIslandPreferenceMigration.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/config/SuperIslandPreferenceMigration.kt
@@ -25,6 +25,7 @@ package com.example.islandlyrics.ui.overlay.superisland.config
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.example.islandlyrics.core.settings.AppPreferences
+import com.example.islandlyrics.core.settings.LabFeatureManager
 
 /**
  * 旧版本「通知按键」偏好迁移到新版「播放按键布局 + 显示进度条」推导模型：
@@ -34,8 +35,13 @@ import com.example.islandlyrics.core.settings.AppPreferences
  */
 internal object SuperIslandPreferenceMigration {
     private const val KEY_MIGRATED = "super_island_notification_logic_v2_migrated"
+    private const val KEY_FORCED_SCROLLING = "super_island_lyric_mode_forced_disable_scrolling"
+    private const val KEY_LEGACY_FORCED_SCROLLING = "full_super_island_forced_disable_scrolling"
+    private const val KEY_SCROLLING_BACKUP = "disable_lyric_scrolling_before_super_island_lyric_mode"
+    private const val KEY_LEGACY_SCROLLING_BACKUP = "disable_lyric_scrolling_before_full_super_island"
 
     fun migrate(prefs: SharedPreferences) {
+        restoreScrollingPreferenceIfNoLongerForced(prefs)
         if (prefs.getBoolean(KEY_MIGRATED, false)) return
 
         val actionStyle = prefs.getString(AppPreferences.Keys.NOTIFICATION_ACTIONS_STYLE, "disabled")
@@ -60,6 +66,29 @@ internal object SuperIslandPreferenceMigration {
                 )
             }
             putBoolean(KEY_MIGRATED, true)
+        }
+    }
+
+    private fun restoreScrollingPreferenceIfNoLongerForced(prefs: SharedPreferences) {
+        val wasForced = prefs.getBoolean(KEY_FORCED_SCROLLING, false) ||
+            prefs.getBoolean(KEY_LEGACY_FORCED_SCROLLING, false)
+        if (!wasForced ||
+            AppPreferences.superIslandNotificationStyle(prefs) != LabFeatureManager.SUPER_ISLAND_STYLE_STANDARD
+        ) {
+            return
+        }
+
+        val restoredValue = if (prefs.contains(KEY_SCROLLING_BACKUP)) {
+            prefs.getBoolean(KEY_SCROLLING_BACKUP, false)
+        } else {
+            prefs.getBoolean(KEY_LEGACY_SCROLLING_BACKUP, false)
+        }
+        prefs.edit {
+            putBoolean(AppPreferences.Keys.DISABLE_LYRIC_SCROLLING, restoredValue)
+            remove(KEY_SCROLLING_BACKUP)
+            remove(KEY_FORCED_SCROLLING)
+            remove(KEY_LEGACY_SCROLLING_BACKUP)
+            remove(KEY_LEGACY_FORCED_SCROLLING)
         }
     }
 }

--- a/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/render/SuperIslandBigAreaRenderer.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/render/SuperIslandBigAreaRenderer.kt
@@ -62,7 +62,8 @@ internal object SuperIslandBigAreaRenderer {
         islandKey: String?,
         showHighlightColor: Boolean,
         title: String = "",
-        artist: String = ""
+        artist: String = "",
+        enableStandardFullLyricScrolling: Boolean = false
     ) {
         if (config.lyricMode == "full") {
             applyFullMode(
@@ -74,7 +75,8 @@ internal object SuperIslandBigAreaRenderer {
                 islandKey = islandKey,
                 showHighlightColor = showHighlightColor,
                 title = title,
-                artist = artist
+                artist = artist,
+                enableStandardFullLyricScrolling = enableStandardFullLyricScrolling
             )
             return
         }
@@ -120,9 +122,15 @@ internal object SuperIslandBigAreaRenderer {
         islandKey: String?,
         showHighlightColor: Boolean,
         title: String,
-        artist: String
+        artist: String,
+        enableStandardFullLyricScrolling: Boolean
     ) {
-        val resolvedLyric = sequenceOf(fullLyric, displayLyric)
+        val lyricCandidates = if (enableStandardFullLyricScrolling) {
+            sequenceOf(displayLyric, fullLyric)
+        } else {
+            sequenceOf(fullLyric, displayLyric)
+        }
+        val resolvedLyric = lyricCandidates
             .firstOrNull { !SuperIslandTextResolver.isPlaceholder(it) }
             .orEmpty()
         val hasLyric = resolvedLyric.isNotBlank()
@@ -158,7 +166,8 @@ internal object SuperIslandBigAreaRenderer {
             leftText = split.left.ifEmpty { "♪" },
             rightText = split.right.ifEmpty { "♪" },
             showHighlightColor = showHighlightColor,
-            narrowLeftFont = false
+            narrowLeftFont = false,
+            useMatchingRightColumn = enableStandardFullLyricScrolling
         )
     }
 
@@ -195,7 +204,8 @@ internal object SuperIslandBigAreaRenderer {
         leftText: String,
         rightText: String,
         showHighlightColor: Boolean,
-        narrowLeftFont: Boolean?
+        narrowLeftFont: Boolean?,
+        useMatchingRightColumn: Boolean = false
     ) {
         imageTextInfoLeft {
             type = 1
@@ -213,10 +223,21 @@ internal object SuperIslandBigAreaRenderer {
                 }
             }
         }
-        this.textInfo = TextInfo().apply {
-            this.title = rightText
-            this.showHighlightColor = showHighlightColor
-            narrowFont = false
+        if (useMatchingRightColumn) {
+            imageTextInfoRight {
+                type = 2
+                textInfo {
+                    this.title = rightText
+                    this.showHighlightColor = showHighlightColor
+                    narrowFont = false
+                }
+            }
+        } else {
+            this.textInfo = TextInfo().apply {
+                this.title = rightText
+                this.showHighlightColor = showHighlightColor
+                narrowFont = false
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/render/SuperIslandStandardFocusBuilder.kt
+++ b/app/src/main/java/com/example/islandlyrics/ui/overlay/superisland/render/SuperIslandStandardFocusBuilder.kt
@@ -28,6 +28,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.Icon
 import com.example.islandlyrics.R
+import com.example.islandlyrics.core.settings.LabFeatureManager
 import com.example.islandlyrics.ui.overlay.model.UIState
 import com.example.islandlyrics.ui.overlay.superisland.cache.SuperIslandIconCache
 import com.example.islandlyrics.ui.overlay.superisland.config.SuperIslandPreferencesCache
@@ -181,7 +182,9 @@ internal class SuperIslandStandardFocusBuilder(
                         islandKey = islandKey,
                         showHighlightColor = showHighlightColor,
                         title = state.title,
-                        artist = state.artist
+                        artist = state.artist,
+                        enableStandardFullLyricScrolling =
+                            preferences.notificationStyle == LabFeatureManager.SUPER_ISLAND_STYLE_STANDARD
                     )
                 }
 

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -815,7 +815,7 @@
     <string name="super_island_lyric_mode_standard">標準模式</string>
     <string name="super_island_lyric_mode_standard_desc">左側顯示播放資訊，右側顯示目前歌詞。適合置中挖孔螢幕。</string>
     <string name="super_island_lyric_mode_full">全歌詞模式</string>
-    <string name="super_island_lyric_mode_full_desc">兩側均顯示歌詞，並自動關閉歌詞滾動。</string>
+    <string name="super_island_lyric_mode_full_desc">左右兩側均顯示歌詞；標準樣式會平滑捲動長歌詞，高級樣式仍自動關閉捲動。</string>
     <string name="settings_super_island_full_lyric_show_left_cover">全歌詞模式顯示左側封面</string>
     <string name="settings_super_island_full_lyric_show_left_cover_desc">在全歌詞樣式下，保留左側小島區域的專輯封面。</string>
     <string name="settings_super_island_standard_show_left_cover">標準模式顯示左側封面</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -815,7 +815,7 @@
     <string name="super_island_lyric_mode_standard">標準</string>
     <string name="super_island_lyric_mode_standard_desc">左側に再生情報、右側に現在の歌詞を表示。中央パンチホールに最適。</string>
     <string name="super_island_lyric_mode_full">フル歌詞</string>
-    <string name="super_island_lyric_mode_full_desc">両側に歌詞を表示し、自動的に歌詞スクロールを無効化します。</string>
+    <string name="super_island_lyric_mode_full_desc">両側に歌詞を表示します。標準スタイルでは長い歌詞を滑らかにスクロールし、高度なスタイルではスクロールを無効にします。</string>
     <string name="settings_super_island_full_lyric_show_left_cover">フル歌詞モードで左にアルバムアートを表示</string>
     <string name="settings_super_island_full_lyric_show_left_cover_desc">フル歌詞スタイルでも左側アイランドエリアにアルバムアートを表示します。</string>
     <string name="settings_super_island_standard_show_left_cover">標準スタイルで左にアルバムアートを表示</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -815,7 +815,7 @@
     <string name="super_island_lyric_mode_standard">标准</string>
     <string name="super_island_lyric_mode_standard_desc">左侧显示播放信息，右侧显示当前歌词。适合常规中置摄像头设备。</string>
     <string name="super_island_lyric_mode_full">全歌词</string>
-    <string name="super_island_lyric_mode_full_desc">左右两侧均显示歌词，并自动关闭歌词滚动。</string>
+    <string name="super_island_lyric_mode_full_desc">左右两侧均显示歌词；标准样式会平滑滚动长歌词，高级样式仍自动关闭滚动。</string>
     <string name="settings_super_island_full_lyric_show_left_cover">左侧显示专辑封面</string>
     <string name="settings_super_island_full_lyric_show_left_cover_desc">全歌词模式下保留左侧岛区域的专辑封面。</string>
     <string name="settings_super_island_standard_show_left_cover">左侧显示专辑封面</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -447,7 +447,7 @@
     <string name="super_island_lyric_mode_standard">Standard</string>
     <string name="super_island_lyric_mode_standard_desc">Shows playback info on the left and the current lyric on the right. Best for centered camera cutouts.</string>
     <string name="super_island_lyric_mode_full">Full Lyrics</string>
-    <string name="super_island_lyric_mode_full_desc">Shows lyrics on both sides and disables lyric scrolling automatically.</string>
+    <string name="super_island_lyric_mode_full_desc">Shows lyrics on both sides. Standard style scrolls long lines smoothly; advanced styles keep scrolling disabled.</string>
     <string name="settings_super_island_full_lyric_show_left_cover">Show Album Cover on Left</string>
     <string name="settings_super_island_full_lyric_show_left_cover_desc">Keep the album cover in the left island area in Full Lyrics mode.</string>
     <string name="settings_super_island_standard_show_left_cover">Show Album Cover on Left</string>


### PR DESCRIPTION
- 按歌词 startTime/endTime 做句内线性滚动，解决长歌词前段停滞、末尾冲刺的问题
- 左右两栏统一使用匹配的 imageTextInfo 组件并关闭 narrowFont，统一字体大小和布局
- 右栏改用 imageTextInfoRight(type = 2)，避开中置摄像头中心区域，改善摄像头左右文字被遮挡、看不清的问题
- 仅高级超级岛样式继续强制关闭滚动，并兼容旧版本滚动偏好