### PR TITLE
feat(ui): 新增液态玻璃样式导航栏

### DIFF
--- a/.gitee/ISSUE_TEMPLATE/bug_report.yml
+++ b/.gitee/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug Report / Issue 提交
+description: Report a bug or request a feature / 提交缺陷报告或功能需求
+title: "[BUG/REQ]: "
+labels: ["triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢您提交 Issue！请填写以下信息以帮助我们更好地了解问题。
+        Thanks for opening an issue! Please fill out the following information to help us understand the problem better.
+  - type: dropdown
+    id: type
+    attributes:
+      label: Issue Type / 问题类型
+      description: What kind of issue are you reporting? / 您要报告什么类型的问题？
+      options:
+        - bug (缺陷报告)
+        - enhancement (功能需求)
+        - question (咨询)
+        - document (文档改进)
+    validations:
+      required: true
+  - type: input
+    id: app_version
+    attributes:
+      label: App Version / 软件版本
+      description: |
+        Please provide the version name (e.g. `26.4_C338` or `26.4.Preview_C338`). 
+        **Tip: Click the version number in the app Settings to copy.**
+        请提供版本号（例如 `26.4_C338` 或 `26.4.Preview_C338`）。
+        **提示：在应用设置中点击版本号即可复制。**
+      placeholder: e.g. 26.4.Preview_C338 or 26.4.Canary_C341
+    validations:
+      required: true
+  - type: dropdown
+    id: os_version
+    attributes:
+      label: System Version / 系统版本
+      options:
+        - HyperOS 3.0.300+
+        - HyperOS 3.0 Android 16
+        - HyperOS 3.0 Android 15
+        - ColorOS 16
+        - OneUI 8
+        - 类原生 Android 16
+        - 其他 (Optional: Specify in details / 请在详情中注明)
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Detailed Description / 详细描述
+      description: Describe the issue in detail. / 请详细描述问题。
+      placeholder: |
+        Steps to reproduce:
+        1. ...
+        2. ...
+        Expected behavior:
+        Actual behavior:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / 日志内容 (Optional)
+      description: |
+        How to get logs / 如何获取日志:
+        - **Debug Version**: Has a built-in Log Console to view full logs directly.
+        - **Stable / Preview / Experiment Version**: Tap the version number or Commit hash in the app multiple times to open the Log Console.
+        
+        - **Debug 版本**: 自带 Log Console（日志控制台），可直接查看输出的完整日志。
+        - **Stable / Preview / Experiment 版本**: 在应用内找到版本号或 Commit 号，连续点击即可唤出 Log Console。
+      placeholder: Paste your logs here or share a link...
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission Checklist / 提交前检查
+      options:
+        - label: I have searched for existing issues. / 我已搜索过现有的 Issue。
+          required: true

--- a/.gitee/ISSUE_TEMPLATE/bug_report.yml
+++ b/.gitee/ISSUE_TEMPLATE/bug_report.yml
@@ -14,10 +14,10 @@ body:
       label: Issue Type / 问题类型
       description: What kind of issue are you reporting? / 您要报告什么类型的问题？
       options:
-        - bug (缺陷报告)
-        - enhancement (功能需求)
-        - question (咨询)
-        - document (文档改进)
+        - "bug (缺陷报告)"
+        - "enhancement (功能需求)"
+        - "question (咨询)"
+        - "document (文档改进)"
     validations:
       required: true
   - type: input
@@ -37,13 +37,15 @@ body:
     attributes:
       label: System Version / 系统版本
       options:
-        - HyperOS 3.0.300+
-        - HyperOS 3.0 Android 16
-        - HyperOS 3.0 Android 15
-        - ColorOS 16
-        - OneUI 8
-        - 类原生 Android 16
-        - 其他 (Optional: Specify in details / 请在详情中注明)
+        - "HyperOS 4"
+        - "HyperOS 3.0.300+"
+        - "HyperOS 3.0 Android 16"
+        - "HyperOS 3.0 Android 15"
+        - "ColorOS"
+        - "OneUI"
+        - "类原生 Android 17"
+        - "类原生 Android 16"
+        - "其他 (Optional: Specify in details / 请在详情中注明)"
     validations:
       required: true
   - type: textarea

--- a/.gitee/ISSUE_TEMPLATE/config.yml
+++ b/.gitee/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussion
+    url: https://github.com/FrancoGiudans/Capsulyric/discussions
+    about: Ask questions and get help from the community / 在此处提问并获取社区帮助

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,10 +14,10 @@ body:
       label: Issue Type / 问题类型
       description: What kind of issue are you reporting? / 您要报告什么类型的问题？
       options:
-        - bug (缺陷报告)
-        - enhancement (功能需求)
-        - question (咨询)
-        - document (文档改进)
+        - "bug (缺陷报告)"
+        - "enhancement (功能需求)"
+        - "question (咨询)"
+        - "document (文档改进)"
     validations:
       required: true
   - type: input
@@ -37,13 +37,15 @@ body:
     attributes:
       label: System Version / 系统版本
       options:
-        - HyperOS 3.0.300+
-        - HyperOS 3.0 Android 16
-        - HyperOS 3.0 Android 15
-        - ColorOS 16
-        - OneUI 8
-        - 类原生 Android 16
-        - 其他 (Optional: Specify in details / 请在详情中注明)
+        - "HyperOS 4"
+        - "HyperOS 3.0.300+"
+        - "HyperOS 3.0 Android 16"
+        - "HyperOS 3.0 Android 15"
+        - "ColorOS"
+        - "OneUI"
+        - "类原生 Android 17"
+        - "类原生 Android 16"
+        - "其他 (Optional: Specify in details / 请在详情中注明)"
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Third-party license texts are collected in [LICENSES/](LICENSES/); the full inve
 - [compose-miuix-ui/miuix](https://github.com/compose-miuix-ui/miuix) (Apache-2.0)
   - The self-wrapped controls under `app/src/main/java/com/example/islandlyrics/ui/miuix/` and `ui/material/` (e.g. `MiuixBlurDialog`, `MiuixBlurBottomSheet`, `BlurOverlayDropdownPreference`, `MaterialBlur*`) are modified from or built on miuix components (`OverlayDialog`, `OverlayBottomSheet`, `OverlayDropdownPreference`, `TopAppBar`/`Scaffold`, `MiuixPopupUtils`) and `miuix-blur`. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md). 
   - 自封装控件（如 `MiuixBlurDialog`、`MiuixBlurBottomSheet`、`BlurOverlayDropdownPreference`、`MaterialBlur*`）修改自或基于 miuix 组件与 `miuix-blur`，详见 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。
+- [Kyant0/AndroidLiquidGlass](https://github.com/Kyant0/AndroidLiquidGlass) (`io.github.kyant0:backdrop`, Apache-2.0) — provides the Liquid Glass effects used by the app. / 为本应用提供液态玻璃效果。
 - [xzakota/HyperNotification](https://github.com/xzakota/HyperNotification) (Apache-2.0)
 - Ported/adapted source embeddings (Lyricify-Lyrics-Helper online lyric providers, InstallerX Revived Shizuku helpers, AOSP hidden API stubs) and the full direct-dependency list are documented in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 - 移植/改编的第三方源码（Lyricify-Lyrics-Helper 在线歌词提供方、InstallerX Revived Shizuku 辅助、AOSP hidden API stub）及完整直接依赖清单均记录于 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -174,6 +174,9 @@ The following libraries are **directly declared** in `app/build.gradle.kts` (via
 | activity-compose | `androidx.activity:activity-compose` | 1.13.0 | Apache-2.0 |
 | lifecycle-viewmodel-compose | `androidx.lifecycle:lifecycle-viewmodel-compose` | 2.11.0 | Apache-2.0 |
 | navigationevent-compose | `org.jetbrains.androidx.navigationevent:navigationevent-compose` | 1.1.0 | Apache-2.0 |
+| Backdrop (AndroidLiquidGlass) | `io.github.kyant0:backdrop` | 2.0.1 | Apache-2.0 |
+
+`backdrop` is published from [Kyant0/AndroidLiquidGlass](https://github.com/Kyant0/AndroidLiquidGlass), with `Kyant` listed as the upstream developer. It is used here for the app's Liquid Glass effects; no source code from that project is copied into this repository. / `backdrop` 由 [Kyant0/AndroidLiquidGlass](https://github.com/Kyant0/AndroidLiquidGlass) 发布，上游开发者标注为 `Kyant`，本项目使用它实现液态玻璃效果；本仓库未复制该项目源码。
 
 ### 6.4 Miuix (MIUI-style components)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.material.icons.extended)
     implementation(libs.compose.runtime.livedata)
     implementation(libs.lifecycle.viewmodel.compose)
+    implementation(libs.backdrop)
 
     // Palette for album art color extraction (Monet-style)
     implementation(libs.palette.ktx)

--- a/app/config/libraries/AndroidLiquidGlass.json
+++ b/app/config/libraries/AndroidLiquidGlass.json
@@ -1,0 +1,5 @@
+{
+  "uniqueId": "io.github.kyant0:backdrop",
+  "name": "AndroidLiquidGlass (Backdrop)",
+  "website": "https://github.com/Kyant0/AndroidLiquidGlass"
+}

--- a/app/src/main/java/com/example/islandlyrics/core/settings/AppPreferences.kt
+++ b/app/src/main/java/com/example/islandlyrics/core/settings/AppPreferences.kt
@@ -24,6 +24,18 @@ package com.example.islandlyrics.core.settings
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
+
+enum class MiuixNavigationBarStyle(val preferenceValue: String) {
+    NORMAL("normal"),
+    FLOATING("floating"),
+    LIQUID("liquid");
+
+    companion object {
+        fun fromPreference(value: String?): MiuixNavigationBarStyle =
+            entries.firstOrNull { it.preferenceValue == value } ?: NORMAL
+    }
+}
 
 object AppPreferences {
     const val NAME = "IslandLyricsPrefs"
@@ -58,6 +70,7 @@ object AppPreferences {
         const val LAST_LOG_CLEANUP_TIME = "last_log_cleanup_time"
         const val LANGUAGE_CODE = "language_code"
         const val UI_USE_MIUIX = "ui_use_miuix"
+        const val MIUIX_NAVIGATION_BAR_STYLE = "miuix_navigation_bar_style"
         const val MIUIX_FLOATING_BOTTOM_BAR_ENABLED = "miuix_floating_bottom_bar_enabled"
         const val IS_SETUP_COMPLETE = "is_setup_complete"
         const val RECOMMEND_MEDIA_APP = "recommend_media_app"
@@ -141,6 +154,28 @@ object AppPreferences {
 
     fun of(context: Context): SharedPreferences =
         context.getSharedPreferences(NAME, Context.MODE_PRIVATE)
+
+    fun miuixNavigationBarStyle(prefs: SharedPreferences): MiuixNavigationBarStyle {
+        val storedStyle = prefs.getString(Keys.MIUIX_NAVIGATION_BAR_STYLE, null)
+        if (storedStyle != null) {
+            return MiuixNavigationBarStyle.fromPreference(storedStyle)
+        }
+        return if (prefs.getBoolean(Keys.MIUIX_FLOATING_BOTTOM_BAR_ENABLED, false)) {
+            MiuixNavigationBarStyle.FLOATING
+        } else {
+            MiuixNavigationBarStyle.NORMAL
+        }
+    }
+
+    fun setMiuixNavigationBarStyle(
+        prefs: SharedPreferences,
+        style: MiuixNavigationBarStyle
+    ) {
+        prefs.edit {
+            putString(Keys.MIUIX_NAVIGATION_BAR_STYLE, style.preferenceValue)
+            putBoolean(Keys.MIUIX_FLOATING_BOTTOM_BAR_ENABLED, style != MiuixNavigationBarStyle.NORMAL)
+        }
+    }
 
     fun notificationActionsStyle(prefs: SharedPreferences): String =
         prefs.getString(Keys.NOTIFICATION_ACTIONS_STYLE, Defaults.NOTIFICATION_ACTIONS_STYLE)

--- a/app/src/main/java/com/example/islandlyrics/feature/customsettings/CustomSettingsContract.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/customsettings/CustomSettingsContract.kt
@@ -23,6 +23,7 @@
 package com.example.islandlyrics.feature.customsettings
 
 import com.example.islandlyrics.core.platform.XmsfBypassMode
+import com.example.islandlyrics.core.settings.MiuixNavigationBarStyle
 import com.example.islandlyrics.ui.overlay.config.CapsuleRenderMode
 import com.example.islandlyrics.ui.navigation.PredictiveBackAnimationMode
 import com.example.islandlyrics.ui.navigation.PredictiveBackAnimationStyle
@@ -77,7 +78,7 @@ data class CustomSettingsUiState(
     val superIslandShareEnabled: Boolean = true,
     val superIslandShareFormat: String = "format_1",
     val miuixEnabled: Boolean = true,
-    val miuixFloatingBottomBarEnabled: Boolean = false,
+    val miuixNavigationBarStyle: MiuixNavigationBarStyle = MiuixNavigationBarStyle.NORMAL,
     val predictiveBackEnabled: Boolean = true,
     val predictiveBackAnimationMode: PredictiveBackAnimationMode = PredictiveBackAnimationMode.default,
     val predictiveBackAnimationStyle: PredictiveBackAnimationStyle = PredictiveBackAnimationStyle.default,
@@ -129,7 +130,7 @@ sealed interface CustomSettingsAction {
     data class SetXmsfBypassMode(val value: XmsfBypassMode) : CustomSettingsAction
     data class SetXmsfCustomDurationMs(val value: Int) : CustomSettingsAction
     data class SetMiuixEnabled(val value: Boolean) : CustomSettingsAction
-    data class SetMiuixFloatingBottomBarEnabled(val value: Boolean) : CustomSettingsAction
+    data class SetMiuixNavigationBarStyle(val value: MiuixNavigationBarStyle) : CustomSettingsAction
     data class SetMiuixThemeColorSource(val value: String) : CustomSettingsAction
     data class SetMiuixThemeCustomColor(val value: Int) : CustomSettingsAction
     data class SetMiuixThemeGlobalTintEnabled(val value: Boolean) : CustomSettingsAction

--- a/app/src/main/java/com/example/islandlyrics/feature/customsettings/CustomSettingsViewModel.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/customsettings/CustomSettingsViewModel.kt
@@ -143,8 +143,8 @@ class CustomSettingsViewModel(application: Application) : AndroidViewModel(appli
                 XmsfBypassMode.writeCustomDurationMs(prefs, action.value)
             is CustomSettingsAction.SetMiuixEnabled ->
                 prefs.edit { putBoolean(AppPreferences.Keys.UI_USE_MIUIX, action.value) }
-            is CustomSettingsAction.SetMiuixFloatingBottomBarEnabled ->
-                prefs.edit { putBoolean(AppPreferences.Keys.MIUIX_FLOATING_BOTTOM_BAR_ENABLED, action.value) }
+            is CustomSettingsAction.SetMiuixNavigationBarStyle ->
+                AppPreferences.setMiuixNavigationBarStyle(prefs, action.value)
             is CustomSettingsAction.SetMiuixThemeColorSource ->
                 prefs.edit { putString(AppPreferences.Keys.MIUIX_THEME_COLOR_SOURCE, action.value) }
             is CustomSettingsAction.SetMiuixThemeCustomColor ->
@@ -223,7 +223,7 @@ class CustomSettingsViewModel(application: Application) : AndroidViewModel(appli
             superIslandShareEnabled = AppPreferences.isSuperIslandShareEnabled(prefs),
             superIslandShareFormat = AppPreferences.superIslandShareFormat(prefs),
             miuixEnabled = prefs.getBoolean(AppPreferences.Keys.UI_USE_MIUIX, true),
-            miuixFloatingBottomBarEnabled = prefs.getBoolean(AppPreferences.Keys.MIUIX_FLOATING_BOTTOM_BAR_ENABLED, false),
+            miuixNavigationBarStyle = AppPreferences.miuixNavigationBarStyle(prefs),
             predictiveBackEnabled = prefs.getBoolean(PREF_PREDICTIVE_BACK_ENABLED, true),
             predictiveBackAnimationMode = PredictiveBackAnimationMode.read(prefs),
             predictiveBackAnimationStyle = PredictiveBackAnimationStyle.read(prefs),

--- a/app/src/main/java/com/example/islandlyrics/feature/customsettings/miuix/MiuixCustomSettingsScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/customsettings/miuix/MiuixCustomSettingsScreen.kt
@@ -46,6 +46,7 @@ import com.example.islandlyrics.R
 import com.example.islandlyrics.core.platform.XmsfBypassMode
 import com.example.islandlyrics.core.settings.AppPreferences
 import com.example.islandlyrics.core.settings.LabFeatureManager
+import com.example.islandlyrics.core.settings.MiuixNavigationBarStyle
 import com.example.islandlyrics.core.theme.ThemeHelper
 import com.example.islandlyrics.core.platform.RomUtils
 import com.example.islandlyrics.runtime.service.LyricService
@@ -221,8 +222,8 @@ fun MiuixCustomSettingsScreen(
         mutableStateOf(uiState.superIslandShareFormat)
     }
     var miuixEnabled by remember(uiState.miuixEnabled) { mutableStateOf(uiState.miuixEnabled) }
-    var miuixFloatingBottomBarEnabled by remember(uiState.miuixFloatingBottomBarEnabled) {
-        mutableStateOf(uiState.miuixFloatingBottomBarEnabled)
+    var miuixNavigationBarStyle by remember(uiState.miuixNavigationBarStyle) {
+        mutableStateOf(uiState.miuixNavigationBarStyle)
     }
     var predictiveBackEnabled by remember(uiState.predictiveBackEnabled) {
         mutableStateOf(uiState.predictiveBackEnabled)
@@ -1372,13 +1373,28 @@ fun MiuixCustomSettingsScreen(
                                         )
                                     }
                                     if (miuixEnabled) {
-                                        SuperSwitch(
-                                            title = stringResource(R.string.settings_miuix_floating_bottom_bar),
-                                            summary = stringResource(R.string.settings_miuix_floating_bottom_bar_desc),
-                                            checked = miuixFloatingBottomBarEnabled,
-                                            onCheckedChange = {
-                                                miuixFloatingBottomBarEnabled = it
-                                                viewModel.dispatch(CustomSettingsAction.SetMiuixFloatingBottomBarEnabled(it))
+                                        val navigationBarStyles = MiuixNavigationBarStyle.entries
+                                        val navigationBarStyleLabels = navigationBarStyles.map { style ->
+                                            stringResource(
+                                                when (style) {
+                                                    MiuixNavigationBarStyle.NORMAL -> R.string.settings_navigation_bar_style_normal
+                                                    MiuixNavigationBarStyle.FLOATING -> R.string.settings_navigation_bar_style_floating
+                                                    MiuixNavigationBarStyle.LIQUID -> R.string.settings_navigation_bar_style_liquid
+                                                }
+                                            )
+                                        }
+                                        val currentNavigationBarStyleIndex = navigationBarStyles
+                                            .indexOf(miuixNavigationBarStyle)
+                                            .takeIf { it >= 0 } ?: 0
+                                        SuperDropdown(
+                                            title = stringResource(R.string.settings_navigation_bar_style),
+                                            summary = stringResource(R.string.settings_navigation_bar_style_desc),
+                                            items = navigationBarStyleLabels,
+                                            selectedIndex = currentNavigationBarStyleIndex,
+                                            onSelectedIndexChange = { index ->
+                                                val style = navigationBarStyles[index]
+                                                miuixNavigationBarStyle = style
+                                                viewModel.dispatch(CustomSettingsAction.SetMiuixNavigationBarStyle(style))
                                             }
                                         )
                                     }

--- a/app/src/main/java/com/example/islandlyrics/feature/main/MainActivity.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/main/MainActivity.kt
@@ -30,6 +30,7 @@ import com.example.islandlyrics.core.update.UpdateChecker
 import com.example.islandlyrics.core.logging.AppLogger
 import com.example.islandlyrics.core.network.OfflineModeManager
 import com.example.islandlyrics.core.settings.AppPreferences
+import com.example.islandlyrics.core.settings.MiuixNavigationBarStyle
 import com.example.islandlyrics.runtime.service.MediaMonitorService
 import com.example.islandlyrics.feature.cache.material.CacheManagementScreen
 import com.example.islandlyrics.feature.cache.miuix.MiuixCacheManagementScreen
@@ -55,6 +56,7 @@ import com.example.islandlyrics.feature.logviewer.material.LogViewerScreen
 import com.example.islandlyrics.feature.logviewer.miuix.MiuixLogViewerScreen
 import com.example.islandlyrics.feature.navigation.MaterialTopLevelNavigationBar
 import com.example.islandlyrics.feature.navigation.MiuixTopLevelFloatingNavigationBar
+import com.example.islandlyrics.feature.navigation.MiuixTopLevelLiquidGlassNavigationBar
 import com.example.islandlyrics.feature.navigation.MiuixTopLevelNavigationBar
 import com.example.islandlyrics.feature.navigation.TopLevelDestination
 import com.example.islandlyrics.feature.main.miuix.MiuixMainScreen
@@ -141,6 +143,8 @@ import top.yukonga.miuix.kmp.basic.SnackbarDuration as MiuixSnackbarDuration
 import top.yukonga.miuix.kmp.basic.SnackbarHost as MiuixSnackbarHost
 import top.yukonga.miuix.kmp.basic.SnackbarHostState as MiuixSnackbarHostState
 import top.yukonga.miuix.kmp.basic.SnackbarResult as MiuixSnackbarResult
+import com.kyant.backdrop.backdrops.layerBackdrop as liquidLayerBackdrop
+import com.kyant.backdrop.backdrops.rememberLayerBackdrop as rememberLiquidLayerBackdrop
 
 class MainActivity : BaseActivity() {
 
@@ -507,10 +511,14 @@ class MainActivity : BaseActivity() {
             drawRect(backdropBackground)
             drawContent()
         }
+        val liquidBackdrop = rememberLiquidLayerBackdrop {
+            drawRect(backdropBackground)
+            drawContent()
+        }
         val prefs = remember { AppPreferences.of(this) }
         var blurEnabled by remember { mutableStateOf(prefs.getBoolean(AppPreferences.Keys.CARD_BLUR_ENABLED, false)) }
-        var floatingBottomBarEnabled by remember {
-            mutableStateOf(prefs.getBoolean(AppPreferences.Keys.MIUIX_FLOATING_BOTTOM_BAR_ENABLED, false))
+        var navigationBarStyle by remember {
+            mutableStateOf(AppPreferences.miuixNavigationBarStyle(prefs))
         }
 
         androidx.compose.runtime.LaunchedEffect(pagerState.currentPage) {
@@ -521,8 +529,10 @@ class MainActivity : BaseActivity() {
                 if (key == AppPreferences.Keys.CARD_BLUR_ENABLED) {
                     blurEnabled = prefs.getBoolean(key, false)
                 }
-                if (key == AppPreferences.Keys.MIUIX_FLOATING_BOTTOM_BAR_ENABLED) {
-                    floatingBottomBarEnabled = prefs.getBoolean(key, false)
+                if (key == AppPreferences.Keys.MIUIX_NAVIGATION_BAR_STYLE ||
+                    key == AppPreferences.Keys.MIUIX_FLOATING_BOTTOM_BAR_ENABLED
+                ) {
+                    navigationBarStyle = AppPreferences.miuixNavigationBarStyle(prefs)
                 }
             }
             prefs.registerOnSharedPreferenceChangeListener(listener)
@@ -569,7 +579,9 @@ class MainActivity : BaseActivity() {
                 popupHost = { MiuixPopupHost() },
                 containerColor = Color.Transparent
             ) {
-                val targetBottomBarVisible = (if (floatingBottomBarEnabled) bottomBarVisible else true) && pageStack.isEmpty()
+                val targetBottomBarVisible =
+                    (if (navigationBarStyle == MiuixNavigationBarStyle.NORMAL) true else bottomBarVisible) &&
+                        pageStack.isEmpty()
                 PageStackHost(
                     stack = pageStack,
                     onPop = ::popPage,
@@ -582,6 +594,13 @@ class MainActivity : BaseActivity() {
                             .clipToBounds()
                             .background(MiuixTheme.colorScheme.surface)
                             .then(if (blurEnabled) Modifier.layerBackdrop(backdrop) else Modifier)
+                            .then(
+                                if (navigationBarStyle == MiuixNavigationBarStyle.LIQUID) {
+                                    Modifier.liquidLayerBackdrop(liquidBackdrop)
+                                } else {
+                                    Modifier
+                                }
+                            )
                     ) {
                         HorizontalPager(
                             state = pagerState,
@@ -651,22 +670,48 @@ class MainActivity : BaseActivity() {
                         exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
                         modifier = Modifier
                             .align(Alignment.BottomCenter)
-                            .then(if (floatingBottomBarEnabled) Modifier.padding(horizontal = 4.dp) else Modifier)
+                            .then(
+                                if (navigationBarStyle == MiuixNavigationBarStyle.FLOATING) {
+                                    Modifier.padding(horizontal = 4.dp)
+                                } else {
+                                    Modifier
+                                }
+                            )
                     ) {
-                        if (floatingBottomBarEnabled) {
-                            MiuixTopLevelFloatingNavigationBar(
-                                currentDestination = TopLevelDestination.entries[pagerState.currentPage],
-                                onNavigate = { destination ->
-                                    scope.launch { pagerState.animateScrollToPage(TopLevelDestination.entries.indexOf(destination)) }
-                                }
-                            )
-                        } else {
-                            MiuixTopLevelNavigationBar(
-                                currentDestination = TopLevelDestination.entries[pagerState.currentPage],
-                                onNavigate = { destination ->
-                                    scope.launch { pagerState.animateScrollToPage(TopLevelDestination.entries.indexOf(destination)) }
-                                }
-                            )
+                        when (navigationBarStyle) {
+                            MiuixNavigationBarStyle.NORMAL -> {
+                                MiuixTopLevelNavigationBar(
+                                    currentDestination = TopLevelDestination.entries[pagerState.currentPage],
+                                    onNavigate = { destination ->
+                                        scope.launch {
+                                            pagerState.animateScrollToPage(TopLevelDestination.entries.indexOf(destination))
+                                        }
+                                    }
+                                )
+                            }
+
+                            MiuixNavigationBarStyle.FLOATING -> {
+                                MiuixTopLevelFloatingNavigationBar(
+                                    currentDestination = TopLevelDestination.entries[pagerState.currentPage],
+                                    onNavigate = { destination ->
+                                        scope.launch {
+                                            pagerState.animateScrollToPage(TopLevelDestination.entries.indexOf(destination))
+                                        }
+                                    }
+                                )
+                            }
+
+                            MiuixNavigationBarStyle.LIQUID -> {
+                                MiuixTopLevelLiquidGlassNavigationBar(
+                                    currentDestination = TopLevelDestination.entries[pagerState.currentPage],
+                                    onNavigate = { destination ->
+                                        scope.launch {
+                                            pagerState.animateScrollToPage(TopLevelDestination.entries.indexOf(destination))
+                                        }
+                                    },
+                                    backdrop = liquidBackdrop
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/example/islandlyrics/feature/navigation/TopLevelNavigation.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/navigation/TopLevelNavigation.kt
@@ -26,7 +26,10 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
@@ -36,18 +39,27 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.FormatListBulleted as MaterialFormatListBulleted
 import androidx.compose.material.icons.filled.Home as MaterialHome
@@ -56,19 +68,31 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.islandlyrics.R
 import com.example.islandlyrics.feature.main.MainActivity
 import com.example.islandlyrics.feature.parserrule.ParserRuleActivity
@@ -79,6 +103,18 @@ import com.example.islandlyrics.ui.material.blur.materialBlurPanel
 import com.example.islandlyrics.ui.miuix.blur.LocalMiuixBlurBackdrop
 import com.example.islandlyrics.ui.miuix.blur.LocalMiuixBlurEnabled
 import com.example.islandlyrics.ui.miuix.blur.MiuixBlurNavigationBar
+import com.kyant.backdrop.Backdrop
+import com.kyant.backdrop.drawBackdrop
+import com.kyant.backdrop.effects.blur
+import com.kyant.backdrop.effects.lens
+import com.kyant.backdrop.effects.vibrancy
+import com.kyant.backdrop.highlight.Highlight as LiquidHighlight
+import com.kyant.backdrop.shadow.InnerShadow as LiquidInnerShadow
+import com.kyant.backdrop.shadow.Shadow as LiquidShadow
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlin.math.sign
 import top.yukonga.miuix.kmp.basic.FloatingNavigationBar
 import top.yukonga.miuix.kmp.basic.FloatingNavigationBarItem
 import top.yukonga.miuix.kmp.basic.NavigationBarItem
@@ -288,6 +324,290 @@ fun MiuixTopLevelFloatingNavigationBar(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun MiuixTopLevelLiquidGlassNavigationBar(
+    currentDestination: TopLevelDestination,
+    onNavigate: (TopLevelDestination) -> Unit,
+    backdrop: Backdrop,
+    modifier: Modifier = Modifier,
+) {
+    val destinations = TopLevelDestination.entries
+    val selectedIndex = destinations.indexOf(currentDestination).coerceAtLeast(0)
+    val density = LocalDensity.current
+    val isLtr = LocalLayoutDirection.current == LayoutDirection.Ltr
+    val animationScope = rememberCoroutineScope()
+    val navigationInteractionSource = remember { MutableInteractionSource() }
+    val isNavigationItemPressed by navigationInteractionSource.collectIsPressedAsState()
+    val selectedPosition = remember { Animatable(selectedIndex.toFloat()) }
+    var isDragging by remember { mutableStateOf(false) }
+    var dragPosition by remember { mutableFloatStateOf(selectedIndex.toFloat()) }
+    var dragDistancePx by remember { mutableFloatStateOf(0f) }
+
+    LaunchedEffect(selectedIndex) {
+        if (!isDragging) {
+            selectedPosition.animateTo(
+                targetValue = selectedIndex.toFloat(),
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                    stiffness = Spring.StiffnessMediumLow
+                )
+            )
+        }
+    }
+
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(bottom = 4.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        val barWidth = (maxWidth * 0.76f).coerceIn(280.dp, 360.dp)
+        val containerShape = RoundedCornerShape(32.dp)
+        val indicatorShape = RoundedCornerShape(26.dp)
+        val surfaceColor = MiuixTheme.colorScheme.surfaceContainer
+        val isDark = surfaceColor.luminance() < 0.5f
+        val containerColor = surfaceColor.copy(alpha = if (isDark) 0.42f else 0.36f)
+        val accentColor = MiuixTheme.colorScheme.primary
+        val inactiveColor = MiuixTheme.colorScheme.onSurfaceVariantActions
+
+        BoxWithConstraints(
+            modifier = Modifier
+                .width(barWidth)
+                .height(64.dp)
+        ) {
+            val horizontalPadding = 4.dp
+            val tabWidth = (maxWidth - horizontalPadding * 2) / destinations.size
+            val tabWidthPx = with(density) { tabWidth.toPx() }
+            val maxIndex = destinations.lastIndex.toFloat()
+            val displayedPosition = if (isDragging) dragPosition else selectedPosition.value
+            val elasticPosition = liquidGlassElasticPosition(displayedPosition, maxIndex)
+            val dragFraction = if (constraints.maxWidth > 0) {
+                (abs(dragDistancePx) / constraints.maxWidth).coerceIn(0f, 1f)
+            } else {
+                0f
+            }
+            val targetPanelOffsetPx = with(density) { 4.dp.toPx() } *
+                dragDistancePx.sign * EaseOut.transform(dragFraction)
+            val panelOffsetPx by animateFloatAsState(
+                targetValue = if (isDragging) targetPanelOffsetPx else 0f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                    stiffness = Spring.StiffnessMedium
+                ),
+                label = "liquidNavigationPanelOffset"
+            )
+            val pressProgress by animateFloatAsState(
+                targetValue = if (isDragging || isNavigationItemPressed) 1f else 0f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                    stiffness = Spring.StiffnessMediumLow
+                ),
+                label = "liquidNavigationPressProgress"
+            )
+            val indicatorScaleX by animateFloatAsState(
+                targetValue = 1f + pressProgress * (0.16f + dragFraction * 0.06f),
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                    stiffness = Spring.StiffnessMediumLow
+                ),
+                label = "liquidNavigationIndicatorScaleX"
+            )
+            val indicatorScaleY by animateFloatAsState(
+                targetValue = 1f + pressProgress * 0.08f,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                    stiffness = Spring.StiffnessMediumLow
+                ),
+                label = "liquidNavigationIndicatorScaleY"
+            )
+
+            fun finishDrag(navigate: Boolean) {
+                val targetIndex = if (navigate) {
+                    dragPosition.roundToInt().coerceIn(0, destinations.lastIndex)
+                } else {
+                    selectedIndex
+                }
+                val settledPosition = dragPosition.coerceIn(0f, maxIndex)
+                animationScope.launch {
+                    selectedPosition.stop()
+                    selectedPosition.snapTo(settledPosition)
+                    isDragging = false
+                    dragDistancePx = 0f
+                    selectedPosition.animateTo(
+                        targetValue = targetIndex.toFloat(),
+                        animationSpec = spring(
+                            dampingRatio = Spring.DampingRatioMediumBouncy,
+                            stiffness = Spring.StiffnessMediumLow
+                        )
+                    )
+                }
+                if (navigate) {
+                    onNavigate(destinations[targetIndex])
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp)
+                    .graphicsLayer { translationX = panelOffsetPx }
+                    .drawBackdrop(
+                        backdrop = backdrop,
+                        shape = { containerShape },
+                        effects = {
+                            vibrancy()
+                            blur(8.dp.toPx())
+                            lens(24.dp.toPx(), 24.dp.toPx())
+                        },
+                        highlight = { LiquidHighlight.Ambient.copy(alpha = 0.9f) },
+                        shadow = { LiquidShadow(radius = 18.dp, alpha = 0.8f) },
+                        innerShadow = { LiquidInnerShadow(radius = 12.dp, alpha = 0.32f) },
+                        onDrawSurface = { drawRect(containerColor) }
+                    )
+                    .pointerInput(tabWidthPx, isLtr) {
+                        detectDragGestures(
+                            onDragStart = {
+                                dragPosition = selectedPosition.value
+                                dragDistancePx = 0f
+                                isDragging = true
+                                animationScope.launch { selectedPosition.stop() }
+                            },
+                            onDragEnd = { finishDrag(navigate = true) },
+                            onDragCancel = { finishDrag(navigate = false) }
+                        ) { change, dragAmount ->
+                            change.consume()
+                            dragDistancePx += dragAmount.x
+                            val direction = if (isLtr) 1f else -1f
+                            dragPosition = (
+                                dragPosition + direction * dragAmount.x / tabWidthPx
+                                ).coerceIn(-0.35f, maxIndex + 0.35f)
+                        }
+                    }
+            ) {
+                Box(
+                    modifier = Modifier
+                        .padding(start = horizontalPadding, top = 4.dp, bottom = 4.dp)
+                        .width(tabWidth)
+                        .fillMaxHeight()
+                        .graphicsLayer {
+                            translationX = elasticPosition * tabWidthPx * if (isLtr) 1f else -1f
+                            scaleX = indicatorScaleX
+                            scaleY = indicatorScaleY
+                        }
+                        .drawBackdrop(
+                            backdrop = backdrop,
+                            shape = { indicatorShape },
+                            effects = {
+                                blur(2.dp.toPx())
+                                lens(
+                                    refractionHeight = (8.dp + 4.dp * pressProgress).toPx(),
+                                    refractionAmount = (10.dp + 6.dp * pressProgress).toPx(),
+                                    chromaticAberration = pressProgress > 0.35f
+                                )
+                            },
+                            highlight = {
+                                LiquidHighlight.Default.copy(alpha = 0.55f + pressProgress * 0.45f)
+                            },
+                            shadow = {
+                                LiquidShadow(radius = 10.dp, alpha = 0.35f + pressProgress * 0.45f)
+                            },
+                            innerShadow = {
+                                LiquidInnerShadow(radius = 8.dp, alpha = 0.24f + pressProgress * 0.36f)
+                            },
+                            onDrawSurface = {
+                                drawRect(accentColor.copy(alpha = if (isDark) 0.18f else 0.12f))
+                            }
+                        )
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(64.dp)
+                        .padding(horizontal = horizontalPadding)
+                        .selectableGroup(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    destinations.forEachIndexed { index, destination ->
+                        val selected = currentDestination == destination
+                        val label = stringResource(destination.labelRes)
+                        val itemColor by animateColorAsState(
+                            targetValue = if (selected) accentColor else inactiveColor,
+                            animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+                            label = "liquidNavigationItemColor"
+                        )
+                        val itemScale by animateFloatAsState(
+                            targetValue = if (selected) 1.06f else 1f,
+                            animationSpec = spring(
+                                dampingRatio = Spring.DampingRatioMediumBouncy,
+                                stiffness = Spring.StiffnessMediumLow
+                            ),
+                            label = "liquidNavigationItemScale"
+                        )
+                        Column(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight()
+                                .clip(indicatorShape)
+                                .selectable(
+                                    selected = selected,
+                                    role = Role.Tab,
+                                    interactionSource = navigationInteractionSource,
+                                    indication = null,
+                                    onClick = {
+                                        animationScope.launch {
+                                            selectedPosition.animateTo(
+                                                targetValue = index.toFloat(),
+                                                animationSpec = spring(
+                                                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                                                    stiffness = Spring.StiffnessMediumLow
+                                                )
+                                            )
+                                        }
+                                        onNavigate(destination)
+                                    }
+                                )
+                                .graphicsLayer {
+                                    scaleX = itemScale
+                                    scaleY = itemScale
+                                },
+                            verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Icon(
+                                imageVector = destination.miuixIcon(selected),
+                                contentDescription = label,
+                                tint = itemColor,
+                                modifier = Modifier.size(24.dp)
+                            )
+                            Text(
+                                text = label,
+                                color = itemColor,
+                                fontSize = 11.sp,
+                                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun liquidGlassElasticPosition(position: Float, maxIndex: Float): Float {
+    return when {
+        position < 0f -> -(-position / (1f + -position * 2f))
+        position > maxIndex -> {
+            val overflow = position - maxIndex
+            maxIndex + overflow / (1f + overflow * 2f)
+        }
+        else -> position
     }
 }
 

--- a/app/src/main/java/com/example/islandlyrics/feature/navigation/TopLevelNavigation.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/navigation/TopLevelNavigation.kt
@@ -47,6 +47,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -77,6 +78,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
@@ -88,11 +90,13 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
 import com.example.islandlyrics.R
 import com.example.islandlyrics.feature.main.MainActivity
 import com.example.islandlyrics.feature.parserrule.ParserRuleActivity
@@ -104,6 +108,9 @@ import com.example.islandlyrics.ui.miuix.blur.LocalMiuixBlurBackdrop
 import com.example.islandlyrics.ui.miuix.blur.LocalMiuixBlurEnabled
 import com.example.islandlyrics.ui.miuix.blur.MiuixBlurNavigationBar
 import com.kyant.backdrop.Backdrop
+import com.kyant.backdrop.backdrops.layerBackdrop as liquidLayerBackdrop
+import com.kyant.backdrop.backdrops.rememberCombinedBackdrop
+import com.kyant.backdrop.backdrops.rememberLayerBackdrop
 import com.kyant.backdrop.drawBackdrop
 import com.kyant.backdrop.effects.blur
 import com.kyant.backdrop.effects.lens
@@ -341,6 +348,8 @@ fun MiuixTopLevelLiquidGlassNavigationBar(
     val animationScope = rememberCoroutineScope()
     val navigationInteractionSource = remember { MutableInteractionSource() }
     val isNavigationItemPressed by navigationInteractionSource.collectIsPressedAsState()
+    val tabsBackdrop = rememberLayerBackdrop()
+    val combinedBackdrop = rememberCombinedBackdrop(backdrop, tabsBackdrop)
     val selectedPosition = remember { Animatable(selectedIndex.toFloat()) }
     var isDragging by remember { mutableStateOf(false) }
     var dragPosition by remember { mutableFloatStateOf(selectedIndex.toFloat()) }
@@ -369,15 +378,17 @@ fun MiuixTopLevelLiquidGlassNavigationBar(
         val containerShape = RoundedCornerShape(32.dp)
         val indicatorShape = RoundedCornerShape(26.dp)
         val surfaceColor = MiuixTheme.colorScheme.surfaceContainer
-        val isDark = surfaceColor.luminance() < 0.5f
-        val containerColor = surfaceColor.copy(alpha = if (isDark) 0.42f else 0.36f)
+        val containerColor = surfaceColor.copy(alpha = 0.4f)
         val accentColor = MiuixTheme.colorScheme.primary
         val inactiveColor = MiuixTheme.colorScheme.onSurfaceVariantActions
+        val indicatorOverlayColor = MiuixTheme.colorScheme.onSurface.copy(alpha = 0.1f)
+        val indicatorPressedOverlayColor = MiuixTheme.colorScheme.onSurface.copy(alpha = 0.03f)
 
         BoxWithConstraints(
             modifier = Modifier
                 .width(barWidth)
-                .height(64.dp)
+                .height(64.dp),
+            contentAlignment = Alignment.CenterStart
         ) {
             val horizontalPadding = 4.dp
             val tabWidth = (maxWidth - horizontalPadding * 2) / destinations.size
@@ -424,6 +435,7 @@ fun MiuixTopLevelLiquidGlassNavigationBar(
                 ),
                 label = "liquidNavigationIndicatorScaleY"
             )
+            val hiddenTabScale = 1f + pressProgress * 0.2f
 
             fun finishDrag(navigate: Boolean) {
                 val targetIndex = if (navigate) {
@@ -460,12 +472,16 @@ fun MiuixTopLevelLiquidGlassNavigationBar(
                         shape = { containerShape },
                         effects = {
                             vibrancy()
-                            blur(8.dp.toPx())
+                            blur(2.dp.toPx())
                             lens(24.dp.toPx(), 24.dp.toPx())
                         },
-                        highlight = { LiquidHighlight.Ambient.copy(alpha = 0.9f) },
-                        shadow = { LiquidShadow(radius = 18.dp, alpha = 0.8f) },
-                        innerShadow = { LiquidInnerShadow(radius = 12.dp, alpha = 0.32f) },
+                        highlight = { LiquidHighlight.Default.copy(alpha = 0.75f) },
+                        layerBlock = {
+                            val width = size.width.coerceAtLeast(1f)
+                            val scale = 1f + 16.dp.toPx() / width * pressProgress
+                            scaleX = scale
+                            scaleY = scale
+                        },
                         onDrawSurface = { drawRect(containerColor) }
                     )
                     .pointerInput(tabWidthPx, isLtr) {
@@ -488,38 +504,89 @@ fun MiuixTopLevelLiquidGlassNavigationBar(
                         }
                     }
             ) {
+                Row(
+                    modifier = Modifier
+                        .clearAndSetSemantics {}
+                        .alpha(0f)
+                        .liquidLayerBackdrop(tabsBackdrop)
+                        .graphicsLayer { translationX = panelOffsetPx }
+                        .drawBackdrop(
+                            backdrop = backdrop,
+                            shape = { containerShape },
+                            effects = {
+                                vibrancy()
+                                blur(2.dp.toPx())
+                                lens(24.dp.toPx(), 24.dp.toPx())
+                            },
+                            highlight = {
+                                LiquidHighlight.Default.copy(alpha = pressProgress)
+                            },
+                            onDrawSurface = { drawRect(containerColor) }
+                        )
+                        .fillMaxWidth()
+                        .height(56.dp)
+                        .padding(horizontal = horizontalPadding),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    destinations.forEach { destination ->
+                        val selected = currentDestination == destination
+                        LiquidGlassNavigationItemContent(
+                            destination = destination,
+                            selected = selected,
+                            label = stringResource(destination.labelRes),
+                            color = accentColor,
+                            scale = (if (selected) 1.06f else 1f) * hiddenTabScale,
+                            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium
+                        )
+                    }
+                }
+
                 Box(
                     modifier = Modifier
+                        .zIndex(1f)
                         .padding(start = horizontalPadding, top = 4.dp, bottom = 4.dp)
                         .width(tabWidth)
                         .fillMaxHeight()
                         .graphicsLayer {
                             translationX = elasticPosition * tabWidthPx * if (isLtr) 1f else -1f
-                            scaleX = indicatorScaleX
-                            scaleY = indicatorScaleY
                         }
                         .drawBackdrop(
-                            backdrop = backdrop,
+                            backdrop = combinedBackdrop,
                             shape = { indicatorShape },
                             effects = {
-                                blur(2.dp.toPx())
                                 lens(
-                                    refractionHeight = (8.dp + 4.dp * pressProgress).toPx(),
-                                    refractionAmount = (10.dp + 6.dp * pressProgress).toPx(),
+                                    refractionHeight = 10.dp.toPx() * pressProgress,
+                                    refractionAmount = 14.dp.toPx() * pressProgress,
+                                    depthEffect = true,
                                     chromaticAberration = pressProgress > 0.35f
                                 )
                             },
                             highlight = {
-                                LiquidHighlight.Default.copy(alpha = 0.55f + pressProgress * 0.45f)
+                                LiquidHighlight.Default.copy(alpha = pressProgress)
                             },
                             shadow = {
-                                LiquidShadow(radius = 10.dp, alpha = 0.35f + pressProgress * 0.45f)
+                                LiquidShadow(alpha = pressProgress)
                             },
                             innerShadow = {
-                                LiquidInnerShadow(radius = 8.dp, alpha = 0.24f + pressProgress * 0.36f)
+                                LiquidInnerShadow(
+                                    radius = 8.dp * pressProgress,
+                                    alpha = pressProgress
+                                )
+                            },
+                            layerBlock = {
+                                scaleX = indicatorScaleX
+                                scaleY = indicatorScaleY
                             },
                             onDrawSurface = {
-                                drawRect(accentColor.copy(alpha = if (isDark) 0.18f else 0.12f))
+                                drawRect(
+                                    color = indicatorOverlayColor,
+                                    alpha = 1f - pressProgress
+                                )
+                                drawRect(
+                                    indicatorPressedOverlayColor.copy(
+                                        alpha = indicatorPressedOverlayColor.alpha * pressProgress
+                                    )
+                                )
                             }
                         )
                 )
@@ -548,10 +615,14 @@ fun MiuixTopLevelLiquidGlassNavigationBar(
                             ),
                             label = "liquidNavigationItemScale"
                         )
-                        Column(
+                        LiquidGlassNavigationItemContent(
+                            destination = destination,
+                            selected = selected,
+                            label = label,
+                            color = itemColor,
+                            scale = itemScale,
+                            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
                             modifier = Modifier
-                                .weight(1f)
-                                .fillMaxHeight()
                                 .clip(indicatorShape)
                                 .selectable(
                                     selected = selected,
@@ -571,32 +642,50 @@ fun MiuixTopLevelLiquidGlassNavigationBar(
                                         onNavigate(destination)
                                     }
                                 )
-                                .graphicsLayer {
-                                    scaleX = itemScale
-                                    scaleY = itemScale
-                                },
-                            verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Icon(
-                                imageVector = destination.miuixIcon(selected),
-                                contentDescription = label,
-                                tint = itemColor,
-                                modifier = Modifier.size(24.dp)
-                            )
-                            Text(
-                                text = label,
-                                color = itemColor,
-                                fontSize = 11.sp,
-                                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
+                        )
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun RowScope.LiquidGlassNavigationItemContent(
+    destination: TopLevelDestination,
+    selected: Boolean,
+    label: String,
+    color: Color,
+    scale: Float,
+    fontWeight: FontWeight,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxHeight()
+            .then(modifier)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            },
+        verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = destination.miuixIcon(selected),
+            contentDescription = label,
+            tint = color,
+            modifier = Modifier.size(24.dp)
+        )
+        Text(
+            text = label,
+            color = color,
+            fontSize = 11.sp,
+            fontWeight = fontWeight,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -915,8 +915,11 @@
     <string name="diag_lab_experiment_updates_desc">在更新通道中加入 Experiment 選項以接收實驗性更新</string>
     <string name="settings_edge_scroll_haptic_title">邊緣滾動觸覺回饋</string>
     <string name="settings_edge_scroll_haptic_desc">滑動至清單頂部或底部時觸發輕微震動</string>
-    <string name="settings_miuix_floating_bottom_bar">Miuix 懸浮底欄</string>
-    <string name="settings_miuix_floating_bottom_bar_desc">在 Miuix 風格下使用懸浮式底部導覽欄</string>
+    <string name="settings_navigation_bar_style">導覽列樣式</string>
+    <string name="settings_navigation_bar_style_desc">選擇 Miuix 導覽列的外觀與互動樣式</string>
+    <string name="settings_navigation_bar_style_normal">普通樣式</string>
+    <string name="settings_navigation_bar_style_floating">懸浮底欄</string>
+    <string name="settings_navigation_bar_style_liquid">液態懸浮欄</string>
     <string name="diag_lab_floating_lyrics_title">桌面懸浮歌詞入口</string>
     <string name="diag_lab_floating_lyrics_desc">在設定選單中顯示桌面懸浮歌詞的設定項目</string>
     <string name="diag_lab_floating_word_high_fps_title">逐字歌詞高影格率動畫</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -915,8 +915,11 @@
     <string name="diag_lab_experiment_updates_desc">更新チャンネルに Experiment を追加して実験的アップデートを受信</string>
     <string name="settings_edge_scroll_haptic_title">エッジスクロール触覚フィードバック</string>
     <string name="settings_edge_scroll_haptic_desc">リストの端までスクロールした際に軽いバイブレーションを発生</string>
-    <string name="settings_miuix_floating_bottom_bar">Miuix フローティングボトムバー</string>
-    <string name="settings_miuix_floating_bottom_bar_desc">Miuixスタイルでフローティングボトムバーを使用</string>
+    <string name="settings_navigation_bar_style">ナビゲーションバーのスタイル</string>
+    <string name="settings_navigation_bar_style_desc">Miuix ナビゲーションバーの外観と操作スタイルを選択</string>
+    <string name="settings_navigation_bar_style_normal">標準スタイル</string>
+    <string name="settings_navigation_bar_style_floating">フローティングボトムバー</string>
+    <string name="settings_navigation_bar_style_liquid">リキッドフローティングバー</string>
     <string name="diag_lab_floating_lyrics_title">デスクトップフローティング歌詞エントリ</string>
     <string name="diag_lab_floating_lyrics_desc">設定メニューにフローティング歌詞の設定項目を表示</string>
     <string name="diag_lab_floating_word_high_fps_title">文字単位歌詞の高フレームレートアニメーション</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -915,8 +915,11 @@
     <string name="diag_lab_experiment_updates_desc">显示 Experiment 通道，并接收来自测试分支的实验版本。</string>
     <string name="settings_edge_scroll_haptic_title">边缘滚动触感反馈</string>
     <string name="settings_edge_scroll_haptic_desc">滚动到列表边缘时，获得触感反馈。</string>
-    <string name="settings_miuix_floating_bottom_bar">使用悬浮底栏</string>
-    <string name="settings_miuix_floating_bottom_bar_desc">开启后使用悬浮底栏，关闭则使用传统底部导航栏</string>
+    <string name="settings_navigation_bar_style">导航栏样式</string>
+    <string name="settings_navigation_bar_style_desc">选择 Miuix 导航栏的外观和交互样式</string>
+    <string name="settings_navigation_bar_style_normal">普通样式</string>
+    <string name="settings_navigation_bar_style_floating">悬浮底栏</string>
+    <string name="settings_navigation_bar_style_liquid">液态悬浮栏</string>
     <string name="diag_lab_floating_lyrics_title">桌面歌词</string>
     <string name="diag_lab_floating_lyrics_desc">开启后，设置页将显示桌面歌词入口</string>
     <string name="diag_lab_floating_word_high_fps_title">桌面歌词高帧率动画</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -905,8 +905,11 @@ Within the log interface, select the share/export icon. You can specify a timefr
     <string name="diag_lab_experiment_updates_desc">Show the Experiment channel and receive experimental builds from the testing branch.</string>
     <string name="settings_edge_scroll_haptic_title">Scroll End Haptic</string>
     <string name="settings_edge_scroll_haptic_desc">Use the same end-of-list haptic feedback as the miuix demo when scrolling reaches an edge.</string>
-    <string name="settings_miuix_floating_bottom_bar">Use Floating Bottom Bar</string>
-    <string name="settings_miuix_floating_bottom_bar_desc">Use a floating bottom bar instead of the standard navigation bar</string>
+    <string name="settings_navigation_bar_style">Navigation Bar Style</string>
+    <string name="settings_navigation_bar_style_desc">Choose the appearance and interaction style of the Miuix navigation bar</string>
+    <string name="settings_navigation_bar_style_normal">Standard Style</string>
+    <string name="settings_navigation_bar_style_floating">Floating Bottom Bar</string>
+    <string name="settings_navigation_bar_style_liquid">Liquid Floating Bar</string>
     <string name="diag_lab_floating_lyrics_title">Desktop Lyrics</string>
     <string name="diag_lab_floating_lyrics_desc">When enabled, the Desktop Lyrics entry will appear in Settings</string>
     <string name="diag_lab_floating_word_high_fps_title">Desktop Lyrics High-FPS Animation</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ coroutines = "1.11.0"
 navigationEvent = "1.1.0"
 lifecycle = "2.11.0"
 aboutLibraries = "15.1.1"
+backdrop = "2.0.1"
 
 [libraries]
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
@@ -72,6 +73,7 @@ kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 navigationevent-compose = { group = "org.jetbrains.androidx.navigationevent", name = "navigationevent-compose", version.ref = "navigationEvent" }
 aboutlibraries-compose-m3 = { group = "com.mikepenz", name = "aboutlibraries-compose-m3", version.ref = "aboutLibraries" }
+backdrop = { group = "io.github.kyant0", name = "backdrop", version.ref = "backdrop" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
导航栏由悬浮底栏开关改为三选一设置（普通/悬浮底栏/液态悬浮栏），兼容旧偏好键
引入 io.github.kyant0:backdrop 2.0.1（AndroidLiquidGlass, Apache-2.0）实现液态玻璃效果
更新 en/zh/zh-Hant/ja 文案、README 与 THIRD_PARTY_NOTICES 署名