### PR TITLE
ci: 新增 PR 轻量构建检查（develop/main 合并门禁）

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,0 +1,48 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  # NOTE: this job name is used as the required status check in branch
+  # protection rules. Do NOT rename it without updating those rules.
+  build-debug:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 26
+        uses: actions/setup-java@v5
+        with:
+          java-version: '26'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: false
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build Debug Package
+        # No -P version flags needed: gradle/scripts/versioning.gradle falls
+        # back to the date-based prefix and gradle.properties appCodename.
+        # No signing secrets are used so fork PRs can run this check.
+        run: ./gradlew assembleDebug --console=plain


### PR DESCRIPTION
新增 .github/workflows/pr_check.yml：向 develop/main 的 PR 自动跑 assembleDebug，无签名依赖。job 名 build-debug 将作为分支保护的 required status check（勿改名）。