### PR TITLE
feat(backup): 补全 OOBE 导入进度并统一进度逻辑

### DIFF
--- a/app/src/main/java/com/example/islandlyrics/core/settings/SettingsBackupManager.kt
+++ b/app/src/main/java/com/example/islandlyrics/core/settings/SettingsBackupManager.kt
@@ -155,22 +155,6 @@ object SettingsBackupManager {
         return exportToZip(context, uri, allLeafIds, includeLyricCache)
     }
 
-    /** Full import – auto-detects ZIP vs legacy JSON. */
-    suspend fun importFromUri(
-        context: Context,
-        uri: Uri,
-        onProgress: suspend (ImportProgress) -> Unit = {}
-    ): ImportResult {
-        val allLeafIds = BackupCategories.ALL_CATEGORIES.flatMap { c ->
-            if (c.subGroups.isNotEmpty()) c.subGroups.map { it.id } else listOf(c.id)
-        }.toSet()
-        return if (isZipFile(context, uri)) {
-            importFromZip(context, uri, allLeafIds, onProgress = onProgress)
-        } else {
-            importSelected(context, uri, allLeafIds, onProgress = onProgress)
-        }
-    }
-
     // ── ZIP export (always ZIP format) ───────────────────────────────
 
     /**

--- a/app/src/main/java/com/example/islandlyrics/feature/oobe/miuix/MiuixOobeScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/oobe/miuix/MiuixOobeScreen.kt
@@ -105,13 +105,20 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.example.islandlyrics.R
 import com.example.islandlyrics.core.platform.RomUtils
 import com.example.islandlyrics.core.settings.AppPreferences
+import com.example.islandlyrics.core.settings.BackupCategories
 import com.example.islandlyrics.core.settings.SettingsBackupManager
+import com.example.islandlyrics.core.settings.SettingsBackupManager.PreviewResult
 import com.example.islandlyrics.core.theme.ThemeHelper
 import com.example.islandlyrics.feature.customsettings.CustomSettingsActivity
 import com.example.islandlyrics.feature.faq.FAQActivity
 import com.example.islandlyrics.feature.faq.material.FormattedText
 import com.example.islandlyrics.feature.parserrule.ParserRuleActivity
 import com.example.islandlyrics.feature.settings.SettingsActivity
+import com.example.islandlyrics.feature.settings.BackupImportCoordinator
+import com.example.islandlyrics.feature.settings.ParserBackupPreviewReader
+import com.example.islandlyrics.feature.settings.miuix.MiuixBackupCategoryDialog
+import com.example.islandlyrics.feature.settings.miuix.MiuixBackupImportProgressDialog
+import com.example.islandlyrics.feature.settings.miuix.MiuixSensitiveBackupPasswordDialog
 import com.example.islandlyrics.ui.miuix.blur.MiuixBlurDialog
 import com.example.islandlyrics.ui.miuix.blur.MiuixBlurScaffold
 import com.example.islandlyrics.ui.miuix.blur.MiuixBlurTopAppBar
@@ -144,11 +151,21 @@ fun MiuixOobeScreen(
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
+    val backupImportCoordinator = remember(context) { BackupImportCoordinator(context) }
     val backupImportSuccessFormat = stringResource(R.string.settings_backup_import_success)
     val backupImportSuccessWithCacheFormat = stringResource(R.string.settings_backup_import_success_with_cache)
+    val backupImportSuccessWithSensitiveFormat = stringResource(R.string.settings_backup_import_success_with_sensitive)
     val backupImportFailedText = stringResource(R.string.settings_backup_import_failed)
+    val sensitivePasswordInvalidText = stringResource(R.string.backup_sensitive_password_invalid)
     var currentStep by remember { mutableIntStateOf(0) }
     var showRuleGuideDialog by remember { mutableStateOf(false) }
+    var pendingImportUri by remember { mutableStateOf<Uri?>(null) }
+    var pendingImportPreview by remember { mutableStateOf<PreviewResult?>(null) }
+    var selectedImportCategories by remember { mutableStateOf(emptySet<String>()) }
+    var selectedSensitiveImportItems by remember { mutableStateOf(emptySet<String>()) }
+    var showImportCategoryDialog by remember { mutableStateOf(false) }
+    var pendingSensitiveImportPassword by remember { mutableStateOf<CharArray?>(null) }
+    var showSensitiveImportPasswordDialog by remember { mutableStateOf(false) }
     val appIcon = remember { appIconBitmap(context) }
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -181,18 +198,38 @@ fun MiuixOobeScreen(
             guide = stringResource(R.string.oobe_guide_xiaomi)
         )
     )
-    val importSettingsLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocument()
-    ) { uri ->
-        if (uri == null) return@rememberLauncherForActivityResult
+    fun importOobeBackup(
+        uri: Uri,
+        preview: PreviewResult,
+        selectedLeafIds: Set<String>,
+        selectedSensitiveItemIds: Set<String> = emptySet(),
+        sensitivePassword: CharArray? = null,
+    ) {
+        if (backupImportCoordinator.isBusy) {
+            sensitivePassword?.fill('\u0000')
+            return
+        }
         coroutineScope.launch {
-            val result = SettingsBackupManager.importFromUri(context, uri)
+            val result = try {
+                backupImportCoordinator.importSelected(
+                    uri = uri,
+                    preview = preview,
+                    selectedLeafIds = selectedLeafIds,
+                    selectedSensitiveItemIds = selectedSensitiveItemIds,
+                    sensitivePassword = sensitivePassword,
+                )
+            } finally {
+                if (!preview.isZip) sensitivePassword?.fill('\u0000')
+            }
             if (result.success) {
                 // Auto-resolve parser rule conflicts: overwrite all (OOBE backup restore)
                 if (result.parserConflicts.isNotEmpty()) {
                     SettingsBackupManager.resolveParserConflicts(
                         context,
-                        readParserJsonFromImportUri(context, uri),
+                        BackupCategories.filterParserRulesJson(
+                            ParserBackupPreviewReader.read(context, uri),
+                            selectedLeafIds
+                        ),
                         keepExistingPkgs = emptySet()  // overwrite all with imported rules
                     )
                 }
@@ -202,14 +239,67 @@ fun MiuixOobeScreen(
                 if (langCode.isNotEmpty()) {
                     ThemeHelper.setLanguage(context, langCode)
                 }
-                val message = if (result.lyricCacheCount > 0) {
-                    String.format(Locale.getDefault(), backupImportSuccessWithCacheFormat, result.importedCount, result.lyricCacheCount)
-                } else {
-                    String.format(Locale.getDefault(), backupImportSuccessFormat, result.importedCount)
+                val message = when {
+                    result.sensitiveItemCount > 0 -> String.format(
+                        Locale.getDefault(),
+                        backupImportSuccessWithSensitiveFormat,
+                        result.importedCount,
+                        result.lyricCacheCount,
+                        result.sensitiveItemCount
+                    )
+                    result.lyricCacheCount > 0 -> String.format(
+                        Locale.getDefault(),
+                        backupImportSuccessWithCacheFormat,
+                        result.importedCount,
+                        result.lyricCacheCount
+                    )
+                    else -> String.format(
+                        Locale.getDefault(),
+                        backupImportSuccessFormat,
+                        result.importedCount
+                    )
                 }
                 onImportAndFinish(message)
             } else {
                 Toast.makeText(context, backupImportFailedText, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    val importSettingsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        if (backupImportCoordinator.isBusy) return@rememberLauncherForActivityResult
+        coroutineScope.launch {
+            val preview = backupImportCoordinator.preview(uri)
+            if (!preview.success) {
+                Toast.makeText(context, backupImportFailedText, Toast.LENGTH_SHORT).show()
+            } else {
+                pendingImportUri = uri
+                pendingImportPreview = preview
+                val parserJson = ParserBackupPreviewReader.read(context, uri)
+                val dynamicCategories = BackupCategories.ALL_CATEGORIES.map { category ->
+                    if (category.id == "parser_rules") {
+                        category.copy(
+                            subGroups = BackupCategories.parserAppSubGroupsFromJson(parserJson)
+                        )
+                    } else {
+                        category
+                    }
+                }
+                selectedImportCategories = preview.categoryCounts.keys.flatMap { categoryId ->
+                    val category = dynamicCategories.find { it.id == categoryId }
+                    if (category != null && category.subGroups.isNotEmpty()) {
+                        category.subGroups.map { it.id }
+                    } else {
+                        listOf(categoryId)
+                    }
+                }.toSet().let { selected ->
+                    if (preview.lyricCacheEntryCount != 0) selected + "lyric_cache" else selected
+                }
+                selectedSensitiveImportItems = emptySet()
+                showImportCategoryDialog = true
             }
         }
     }
@@ -304,7 +394,9 @@ fun MiuixOobeScreen(
             ) {
                 RestoreStepBody(
                     onImportBackup = {
-                        importSettingsLauncher.launch(arrayOf("application/zip", "application/json", "*/*"))
+                        if (!backupImportCoordinator.isBusy) {
+                            importSettingsLauncher.launch(arrayOf("application/zip", "application/json", "*/*"))
+                        }
                     }
                 )
             }
@@ -357,6 +449,114 @@ fun MiuixOobeScreen(
                 onBack = { currentStep = 4 }
             )
         }
+    }
+    backupImportCoordinator.status?.let { status ->
+        MiuixBackupImportProgressDialog(status = status)
+    }
+    val importPublicCategories = BackupCategories.ALL_CATEGORIES.map { category ->
+        if (category.id == "parser_rules") {
+            val uri = pendingImportUri
+            val parserJson = if (uri != null) {
+                remember(uri) { ParserBackupPreviewReader.readBlocking(context, uri) }
+            } else {
+                null
+            }
+            category.copy(
+                subGroups = BackupCategories.parserAppSubGroupsFromJson(parserJson)
+            )
+        } else {
+            category
+        }
+    }
+    val importCategories = importPublicCategories + listOfNotNull(
+        pendingImportPreview?.let { SettingsBackupManager.sensitiveImportCategory(it) }
+    )
+    MiuixBackupCategoryDialog(
+        show = showImportCategoryDialog && pendingImportPreview != null,
+        titleRes = R.string.backup_dialog_import_title,
+        categories = importCategories,
+        categoryKeyCounts = pendingImportPreview?.categoryCounts,
+        initialSelected = selectedImportCategories,
+        onConfirm = { selected ->
+            val sensitiveItemIds = SettingsBackupManager.selectedSensitiveItemIds(selected)
+            selectedImportCategories = selected
+            selectedSensitiveImportItems = sensitiveItemIds
+            showImportCategoryDialog = false
+            val uri = pendingImportUri
+            val preview = pendingImportPreview
+            if (uri == null || preview == null) return@MiuixBackupCategoryDialog
+            if (sensitiveItemIds.isEmpty()) {
+                pendingImportUri = null
+                pendingImportPreview = null
+                selectedImportCategories = emptySet()
+                selectedSensitiveImportItems = emptySet()
+                importOobeBackup(uri, preview, selected - sensitiveItemIds)
+            } else {
+                showSensitiveImportPasswordDialog = true
+            }
+        },
+        onDismiss = {
+            showImportCategoryDialog = false
+            pendingImportUri = null
+            pendingImportPreview = null
+            selectedImportCategories = emptySet()
+            selectedSensitiveImportItems = emptySet()
+        }
+    )
+    if (showSensitiveImportPasswordDialog) {
+        MiuixSensitiveBackupPasswordDialog(
+            title = stringResource(R.string.backup_sensitive_password_import_title),
+            description = stringResource(R.string.backup_sensitive_password_import_description),
+            requireConfirmation = false,
+            onSubmit = { password ->
+                val uri = pendingImportUri
+                val preview = pendingImportPreview
+                val valid = uri != null && preview != null &&
+                    SettingsBackupManager.verifySensitiveImport(
+                        context,
+                        uri,
+                        selectedSensitiveImportItems,
+                        password.toCharArray()
+                    )
+                if (!valid) {
+                    sensitivePasswordInvalidText
+                } else {
+                    pendingSensitiveImportPassword?.fill('\u0000')
+                    pendingSensitiveImportPassword = password.toCharArray()
+                    null
+                }
+            },
+            onSuccess = {
+                showSensitiveImportPasswordDialog = false
+                val uri = pendingImportUri
+                val preview = pendingImportPreview
+                val password = pendingSensitiveImportPassword
+                val selectedSensitiveItems = selectedSensitiveImportItems
+                val selectedLeafIds = selectedImportCategories - selectedSensitiveItems
+                pendingSensitiveImportPassword = null
+                pendingImportUri = null
+                pendingImportPreview = null
+                selectedSensitiveImportItems = emptySet()
+                selectedImportCategories = emptySet()
+                if (uri != null && preview != null && password != null) {
+                    importOobeBackup(
+                        uri,
+                        preview,
+                        selectedLeafIds,
+                        selectedSensitiveItems,
+                        password
+                    )
+                } else {
+                    password?.fill('\u0000')
+                }
+            },
+            onDismiss = {
+                pendingSensitiveImportPassword?.fill('\u0000')
+                pendingSensitiveImportPassword = null
+                showSensitiveImportPasswordDialog = false
+                showImportCategoryDialog = true
+            }
+        )
     }
     }
 }
@@ -1146,59 +1346,6 @@ private fun checkPostNotification(context: Context): Boolean {
 private fun checkBatteryOptimization(context: Context): Boolean {
     val pm = context.getSystemService(Context.POWER_SERVICE) as android.os.PowerManager
     return pm.isIgnoringBatteryOptimizations(context.packageName)
-}
-
-/** Read parser_rules_json from a backup file (ZIP or legacy JSON) for conflict resolution. */
-private fun readParserJsonFromImportUri(context: Context, uri: Uri): String {
-    return try {
-        val header = ByteArray(4)
-        val isZip = context.contentResolver.openInputStream(uri)?.use { input ->
-            if (input.read(header) == 4) {
-                header[0] == 0x50.toByte() && header[1] == 0x4B.toByte() &&
-                    header[2] == 0x03.toByte() && header[3] == 0x04.toByte()
-            } else false
-        } ?: false
-
-        val text = if (isZip) {
-            val tempDir = java.io.File(context.cacheDir, "oobe_parser_${System.currentTimeMillis()}")
-            tempDir.mkdirs()
-            try {
-                context.contentResolver.openInputStream(uri)?.use { input ->
-                    java.util.zip.ZipInputStream(input).use { zip ->
-                        var entry = zip.nextEntry
-                        while (entry != null) {
-                            if (entry.name == "settings.json" && !entry.isDirectory) {
-                                val targetFile = java.io.File(tempDir, "settings.json")
-                                targetFile.outputStream().use { fileOut -> zip.copyTo(fileOut) }
-                                break
-                            }
-                            zip.closeEntry()
-                            entry = zip.nextEntry
-                        }
-                    }
-                }
-                java.io.File(tempDir, "settings.json").takeIf { it.exists() }?.readText(Charsets.UTF_8) ?: ""
-            } finally {
-                tempDir.deleteRecursively()
-            }
-        } else {
-            context.contentResolver.openInputStream(uri)?.bufferedReader(Charsets.UTF_8)?.readText() ?: ""
-        }
-
-        if (text.isEmpty()) return "[]"
-        val root = org.json.JSONObject(text)
-        val schemaVersion = root.optInt("schema_version", 1)
-        val rawValue = if (schemaVersion >= 2 && root.has("categories")) {
-            val catObj = root.optJSONObject("categories")
-            val parserBlock = catObj?.optJSONObject("parser_rules")
-            parserBlock?.optJSONArray("parsers")
-                ?: parserBlock?.optJSONObject("preferences")?.opt("parser_rules_json")
-        } else {
-            val prefsJson = root.optJSONObject("preferences") ?: root
-            prefsJson.opt("parser_rules_json")
-        }
-        SettingsBackupManager.parserRulesJsonFromBackupValue(rawValue) ?: "[]"
-    } catch (_: Exception) { "[]" }
 }
 
 private const val OOBE_LAST_STEP = 5

--- a/app/src/main/java/com/example/islandlyrics/feature/settings/ParserBackupPreviewReader.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/settings/ParserBackupPreviewReader.kt
@@ -24,7 +24,14 @@ package com.example.islandlyrics.feature.settings
 
 import android.content.Context
 import android.net.Uri
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import com.example.islandlyrics.core.settings.SettingsBackupManager
+import com.example.islandlyrics.core.settings.SettingsBackupManager.ImportProgress
+import com.example.islandlyrics.core.settings.SettingsBackupManager.ImportResult
+import com.example.islandlyrics.core.settings.SettingsBackupManager.ImportStage
+import com.example.islandlyrics.core.settings.SettingsBackupManager.PreviewResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -104,5 +111,155 @@ object ParserBackupPreviewReader {
             prefsJson.opt("parser_rules_json")
         }
         return SettingsBackupManager.parserRulesJsonFromBackupValue(rawValue) ?: "[]"
+    }
+}
+
+/** The two user-visible operations that can report backup progress. */
+enum class BackupImportOperation {
+    PREVIEW,
+    IMPORT,
+}
+
+/** State shared by the Material and Miuix backup surfaces. */
+data class BackupImportStatus(
+    val operation: BackupImportOperation,
+    val isZip: Boolean,
+    val selectedLeafIds: Set<String> = emptySet(),
+    val selectedSensitiveItemIds: Set<String> = emptySet(),
+    val progress: ImportProgress,
+)
+
+/** Shared progress/lifecycle façade around [SettingsBackupManager]. */
+class BackupImportCoordinator(context: Context) {
+    private val appContext = context.applicationContext
+
+    var status by mutableStateOf<BackupImportStatus?>(null)
+        private set
+
+    val isBusy: Boolean
+        get() = status != null
+
+    suspend fun preview(uri: Uri): PreviewResult {
+        return runOperation(
+            operation = BackupImportOperation.PREVIEW,
+            isZip = false,
+        ) { onProgress ->
+            SettingsBackupManager.previewImportFile(appContext, uri, onProgress)
+        }
+    }
+
+    suspend fun importSelected(
+        uri: Uri,
+        preview: PreviewResult,
+        selectedLeafIds: Set<String>,
+        selectedSensitiveItemIds: Set<String> = emptySet(),
+        sensitivePassword: CharArray? = null,
+    ): ImportResult {
+        return runOperation(
+            operation = BackupImportOperation.IMPORT,
+            isZip = preview.isZip,
+            selectedLeafIds = selectedLeafIds,
+            selectedSensitiveItemIds = selectedSensitiveItemIds,
+        ) { onProgress ->
+            if (preview.isZip) {
+                SettingsBackupManager.importFromZip(
+                    appContext,
+                    uri,
+                    selectedLeafIds,
+                    selectedSensitiveItemIds,
+                    sensitivePassword,
+                    onProgress,
+                )
+            } else {
+                SettingsBackupManager.importSelected(
+                    appContext,
+                    uri,
+                    selectedLeafIds,
+                    onProgress,
+                )
+            }
+        }
+    }
+
+    private suspend fun <T> runOperation(
+        operation: BackupImportOperation,
+        isZip: Boolean,
+        selectedLeafIds: Set<String> = emptySet(),
+        selectedSensitiveItemIds: Set<String> = emptySet(),
+        block: suspend (suspend (ImportProgress) -> Unit) -> T,
+    ): T {
+        var archiveDetected = isZip
+        publishStatus(
+            BackupImportStatus(
+                operation = operation,
+                isZip = archiveDetected,
+                selectedLeafIds = selectedLeafIds,
+                selectedSensitiveItemIds = selectedSensitiveItemIds,
+                progress = ImportProgress(ImportStage.READING_BACKUP),
+            )
+        )
+
+        val onProgress: suspend (ImportProgress) -> Unit = { progress ->
+            if (progress.stage == ImportStage.EXTRACTING_ARCHIVE) {
+                archiveDetected = true
+            }
+            publishStatus(
+                BackupImportStatus(
+                    operation = operation,
+                    isZip = archiveDetected,
+                    selectedLeafIds = selectedLeafIds,
+                    selectedSensitiveItemIds = selectedSensitiveItemIds,
+                    progress = progress,
+                )
+            )
+        }
+
+        return try {
+            block(onProgress)
+        } finally {
+            publishStatus(null)
+        }
+    }
+
+    private suspend fun publishStatus(value: BackupImportStatus?) {
+        withContext(Dispatchers.Main.immediate) {
+            status = value
+        }
+    }
+}
+
+/** Keep the progress timeline in one place for both theme-specific dialogs. */
+fun BackupImportStatus.visibleStages(): List<ImportStage> {
+    return buildList {
+        add(ImportStage.READING_BACKUP)
+        if (operation == BackupImportOperation.PREVIEW) {
+            if (progress.stage == ImportStage.EXTRACTING_ARCHIVE) {
+                add(ImportStage.EXTRACTING_ARCHIVE)
+            }
+            return@buildList
+        }
+
+        if (isZip || progress.stage == ImportStage.EXTRACTING_ARCHIVE) {
+            add(ImportStage.EXTRACTING_ARCHIVE)
+        }
+        add(ImportStage.IMPORTING_SETTINGS)
+        if (
+            selectedLeafIds.any { it.startsWith("parser_") } ||
+                progress.stage == ImportStage.IMPORTING_PARSER_RULES
+        ) {
+            add(ImportStage.IMPORTING_PARSER_RULES)
+        }
+        if (
+            selectedLeafIds.contains("lyric_cache") ||
+                progress.stage == ImportStage.IMPORTING_LYRIC_CACHE
+        ) {
+            add(ImportStage.IMPORTING_LYRIC_CACHE)
+        }
+        if (
+            selectedSensitiveItemIds.isNotEmpty() ||
+                progress.stage == ImportStage.RESTORING_SENSITIVE_DATA
+        ) {
+            add(ImportStage.RESTORING_SENSITIVE_DATA)
+        }
     }
 }

--- a/app/src/main/java/com/example/islandlyrics/feature/settings/material/SettingsScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/settings/material/SettingsScreen.kt
@@ -42,6 +42,10 @@ import com.example.islandlyrics.core.platform.RomUtils
 import com.example.islandlyrics.feature.faq.FAQActivity
 import com.example.islandlyrics.feature.lastfm.LastFmSettingsActivity
 import com.example.islandlyrics.feature.settings.AboutActivity
+import com.example.islandlyrics.feature.settings.BackupImportCoordinator
+import com.example.islandlyrics.feature.settings.BackupImportOperation
+import com.example.islandlyrics.feature.settings.BackupImportStatus
+import com.example.islandlyrics.feature.settings.visibleStages
 import com.example.islandlyrics.feature.settings.CommunityDialogState
 import com.example.islandlyrics.feature.settings.CommunityMarkdownBody
 import com.example.islandlyrics.feature.settings.ParserBackupPreviewReader
@@ -111,22 +115,8 @@ import com.example.islandlyrics.runtime.playingapp.NewPlayingAppNotifier
 import com.example.islandlyrics.ui.material.blur.MaterialBlurScaffold
 import com.example.islandlyrics.ui.theme.material.MaterialBlurTopAppBar
 import androidx.core.net.toUri
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.util.Locale
-
-private enum class BackupProgressMode {
-    PREVIEW,
-    IMPORT,
-}
-
-private data class BackupProgressRequest(
-    val mode: BackupProgressMode,
-    val isZip: Boolean,
-    val selectedLeafIds: Set<String> = emptySet(),
-    val selectedSensitiveItemIds: Set<String> = emptySet(),
-)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -158,6 +148,7 @@ fun SettingsScreen(
     val prefs = remember { context.getSharedPreferences("IslandLyricsPrefs", Context.MODE_PRIVATE) }
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val backupImportCoordinator = remember(context) { BackupImportCoordinator(context) }
     val backupExportSuccessFormat = stringResource(R.string.settings_backup_export_success)
     val backupExportSuccessWithCacheFormat = stringResource(R.string.settings_backup_export_success_with_cache)
     val backupExportSuccessWithSensitiveFormat = stringResource(R.string.settings_backup_export_success_with_sensitive)
@@ -188,8 +179,6 @@ fun SettingsScreen(
     var selectedSensitiveImportItems by remember { mutableStateOf(emptySet<String>()) }
     var pendingSensitiveImportPassword by remember { mutableStateOf<CharArray?>(null) }
     var showSensitiveImportPasswordDialog by remember { mutableStateOf(false) }
-    var backupProgressRequest by remember { mutableStateOf<BackupProgressRequest?>(null) }
-    var backupProgress by remember { mutableStateOf<SettingsBackupManager.ImportProgress?>(null) }
 
     // Parser conflict resolution state
     var showParserConflictDialog by remember { mutableStateOf(false) }
@@ -199,12 +188,6 @@ fun SettingsScreen(
     var pendingConflictSelections by remember { mutableStateOf(setOf<String>()) }
     var conflictKeepExisting by remember { mutableStateOf(setOf<String>()) }
 
-    val publishBackupProgress: suspend (SettingsBackupManager.ImportProgress) -> Unit = { progress ->
-        withContext(Dispatchers.Main.immediate) {
-            backupProgress = progress
-        }
-    }
-
     fun importBackup(
         uri: Uri,
         preview: PreviewResult,
@@ -212,39 +195,18 @@ fun SettingsScreen(
         selectedSensitiveItemIds: Set<String>,
         sensitivePassword: CharArray? = null
     ) {
-        if (backupProgressRequest != null) return
-        backupProgressRequest = BackupProgressRequest(
-            mode = BackupProgressMode.IMPORT,
-            isZip = preview.isZip,
-            selectedLeafIds = selectedLeafIds,
-            selectedSensitiveItemIds = selectedSensitiveItemIds,
-        )
-        backupProgress = SettingsBackupManager.ImportProgress(
-            SettingsBackupManager.ImportStage.READING_BACKUP
-        )
+        if (backupImportCoordinator.isBusy) return
         coroutineScope.launch {
             val result = try {
-                if (preview.isZip) {
-                    SettingsBackupManager.importFromZip(
-                        context,
-                        uri,
-                        selectedLeafIds,
-                        selectedSensitiveItemIds,
-                        sensitivePassword,
-                        publishBackupProgress
-                    )
-                } else {
-                    SettingsBackupManager.importSelected(
-                        context,
-                        uri,
-                        selectedLeafIds,
-                        publishBackupProgress
-                    )
-                }
+                backupImportCoordinator.importSelected(
+                    uri = uri,
+                    preview = preview,
+                    selectedLeafIds = selectedLeafIds,
+                    selectedSensitiveItemIds = selectedSensitiveItemIds,
+                    sensitivePassword = sensitivePassword,
+                )
             } finally {
                 if (!preview.isZip) sensitivePassword?.fill('\u0000')
-                backupProgressRequest = null
-                backupProgress = null
             }
             if (result.success && result.parserConflicts.isNotEmpty()) {
                 parserConflicts = result.parserConflicts
@@ -330,54 +292,38 @@ fun SettingsScreen(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
-        if (backupProgressRequest != null) return@rememberLauncherForActivityResult
-        backupProgressRequest = BackupProgressRequest(
-            mode = BackupProgressMode.PREVIEW,
-            isZip = false,
-        )
-        backupProgress = SettingsBackupManager.ImportProgress(
-            SettingsBackupManager.ImportStage.READING_BACKUP
-        )
+        if (backupImportCoordinator.isBusy) return@rememberLauncherForActivityResult
         coroutineScope.launch {
-            try {
-                val preview = SettingsBackupManager.previewImportFile(
-                    context,
-                    uri,
-                    publishBackupProgress
-                )
-                if (preview.success) {
-                    importPreviewResult = preview
-                    pendingImportUri = uri
-                    // Build dynamic categories list (including parser rules from backup file)
-                    val parserJson = ParserBackupPreviewReader.read(context, uri)
-                    val dynamicCategoriesList = BackupCategories.ALL_CATEGORIES.map { cat ->
-                        when (cat.id) {
-                            "parser_rules" -> cat.copy(
-                                subGroups = BackupCategories.parserAppSubGroupsFromJson(parserJson)
-                            )
-                            else -> cat
-                        }
+            val preview = backupImportCoordinator.preview(uri)
+            if (preview.success) {
+                importPreviewResult = preview
+                pendingImportUri = uri
+                // Build dynamic categories list (including parser rules from backup file)
+                val parserJson = ParserBackupPreviewReader.read(context, uri)
+                val dynamicCategoriesList = BackupCategories.ALL_CATEGORIES.map { cat ->
+                    when (cat.id) {
+                        "parser_rules" -> cat.copy(
+                            subGroups = BackupCategories.parserAppSubGroupsFromJson(parserJson)
+                        )
+                        else -> cat
                     }
-                    // Convert category IDs to leaf IDs for the dialog - ALL selected by default
-                    selectedImportCategories = preview.categoryCounts.keys.flatMap { catId ->
-                        val cat = dynamicCategoriesList.find { it.id == catId }
-                        if (cat != null && cat.subGroups.isNotEmpty()) {
-                            cat.subGroups.map { it.id }
-                        } else {
-                            listOf(catId)
-                        }
-                    }.toSet()
-                    // Also include lyric_cache if present in ZIP
-                    if (preview.lyricCacheEntryCount != 0) {
-                        selectedImportCategories = selectedImportCategories + "lyric_cache"
-                    }
-                    showImportPreviewDialog = true
-                } else {
-                    snackbarHostState.showSnackbar(backupImportFailedText)
                 }
-            } finally {
-                backupProgressRequest = null
-                backupProgress = null
+                // Convert category IDs to leaf IDs for the dialog - ALL selected by default
+                selectedImportCategories = preview.categoryCounts.keys.flatMap { catId ->
+                    val cat = dynamicCategoriesList.find { it.id == catId }
+                    if (cat != null && cat.subGroups.isNotEmpty()) {
+                        cat.subGroups.map { it.id }
+                    } else {
+                        listOf(catId)
+                    }
+                }.toSet()
+                // Also include lyric_cache if present in ZIP
+                if (preview.lyricCacheEntryCount != 0) {
+                    selectedImportCategories = selectedImportCategories + "lyric_cache"
+                }
+                showImportPreviewDialog = true
+            } else {
+                snackbarHostState.showSnackbar(backupImportFailedText)
             }
         }
     }
@@ -1120,46 +1066,18 @@ fun SettingsScreen(
             )
         }
 
-        backupProgressRequest?.let { request ->
-            backupProgress?.let { progress ->
-                BackupImportProgressDialog(
-                    request = request,
-                    progress = progress,
-                )
-            }
+        backupImportCoordinator.status?.let { status ->
+            BackupImportProgressDialog(status = status)
         }
     }
 }
 
 @Composable
 private fun BackupImportProgressDialog(
-    request: BackupProgressRequest,
-    progress: SettingsBackupManager.ImportProgress,
+    status: BackupImportStatus,
 ) {
-    val stages = buildList {
-        add(SettingsBackupManager.ImportStage.READING_BACKUP)
-        if (request.mode == BackupProgressMode.PREVIEW) {
-            if (progress.stage == SettingsBackupManager.ImportStage.EXTRACTING_ARCHIVE) {
-                add(SettingsBackupManager.ImportStage.EXTRACTING_ARCHIVE)
-            }
-        } else {
-            if (request.isZip) add(SettingsBackupManager.ImportStage.EXTRACTING_ARCHIVE)
-            add(SettingsBackupManager.ImportStage.IMPORTING_SETTINGS)
-            if (
-                request.selectedLeafIds.any { it.startsWith("parser_") } ||
-                progress.stage == SettingsBackupManager.ImportStage.IMPORTING_PARSER_RULES
-            ) {
-                add(SettingsBackupManager.ImportStage.IMPORTING_PARSER_RULES)
-            }
-            if (request.selectedLeafIds.contains("lyric_cache")) {
-                add(SettingsBackupManager.ImportStage.IMPORTING_LYRIC_CACHE)
-            }
-            if (request.selectedSensitiveItemIds.isNotEmpty()) {
-                add(SettingsBackupManager.ImportStage.RESTORING_SENSITIVE_DATA)
-            }
-        }
-    }
-    val currentIndex = stages.indexOf(progress.stage).let { if (it >= 0) it else 0 }
+    val stages = status.visibleStages()
+    val currentIndex = stages.indexOf(status.progress.stage).let { if (it >= 0) it else 0 }
 
     MaterialBlurAlertDialog(
         onDismissRequest = {},
@@ -1170,7 +1088,7 @@ private fun BackupImportProgressDialog(
         title = {
             Text(
                 stringResource(
-                    if (request.mode == BackupProgressMode.PREVIEW) {
+                    if (status.operation == BackupImportOperation.PREVIEW) {
                         R.string.backup_progress_preview_title
                     } else {
                         R.string.backup_progress_import_title

--- a/app/src/main/java/com/example/islandlyrics/feature/settings/miuix/MiuixSettingsScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/settings/miuix/MiuixSettingsScreen.kt
@@ -38,6 +38,10 @@ import com.example.islandlyrics.core.platform.RomUtils
 import com.example.islandlyrics.feature.faq.FAQActivity
 import com.example.islandlyrics.feature.lastfm.LastFmSettingsActivity
 import com.example.islandlyrics.feature.settings.AboutActivity
+import com.example.islandlyrics.feature.settings.BackupImportCoordinator
+import com.example.islandlyrics.feature.settings.BackupImportOperation
+import com.example.islandlyrics.feature.settings.BackupImportStatus
+import com.example.islandlyrics.feature.settings.visibleStages
 import com.example.islandlyrics.feature.settings.CommunityDialogState
 import com.example.islandlyrics.feature.settings.CommunityMarkdownBody
 import com.example.islandlyrics.feature.settings.ParserBackupPreviewReader
@@ -75,8 +79,6 @@ import androidx.core.content.edit
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import top.yukonga.miuix.kmp.basic.*
 import top.yukonga.miuix.kmp.preference.ArrowPreference as SuperArrow
 import com.example.islandlyrics.ui.miuix.preference.BlurOverlayDropdownPreference as SuperDropdown
@@ -110,18 +112,6 @@ import com.example.islandlyrics.ui.miuix.blur.MiuixBlurSnackbar
 import top.yukonga.miuix.kmp.basic.SnackbarHost as MiuixSnackbarHost
 import top.yukonga.miuix.kmp.basic.SnackbarHostState as MiuixSnackbarHostState
 import java.util.Locale
-
-private enum class BackupProgressMode {
-    PREVIEW,
-    IMPORT,
-}
-
-private data class BackupProgressRequest(
-    val mode: BackupProgressMode,
-    val isZip: Boolean,
-    val selectedLeafIds: Set<String> = emptySet(),
-    val selectedSensitiveItemIds: Set<String> = emptySet(),
-)
 
 @Composable
 @SuppressLint("BatteryLife")
@@ -158,6 +148,7 @@ fun MiuixSettingsScreen(
     val offlineModeEnabled = OfflineModeManager.isEnabled(context)
     val snackbarHostState = remember { MiuixSnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val backupImportCoordinator = remember(context) { BackupImportCoordinator(context) }
     val scrollBehavior = MiuixScrollBehavior(rememberTopAppBarState())
     val listState = rememberLazyListState()
     val backupExportSuccessFormat = stringResource(R.string.settings_backup_export_success)
@@ -206,20 +197,12 @@ fun MiuixSettingsScreen(
     var selectedSensitiveImportItems by remember { mutableStateOf(emptySet<String>()) }
     var pendingSensitiveImportPassword by remember { mutableStateOf<CharArray?>(null) }
     var showSensitiveImportPasswordDialog by remember { mutableStateOf(false) }
-    var backupProgressRequest by remember { mutableStateOf<BackupProgressRequest?>(null) }
-    var backupProgress by remember { mutableStateOf<SettingsBackupManager.ImportProgress?>(null) }
 
     var showParserConflictDialog by remember { mutableStateOf(false) }
     var parserConflicts by remember { mutableStateOf<List<ParserConflict>>(emptyList()) }
     var pendingConflictImportUri by remember { mutableStateOf<Uri?>(null) }
     var pendingConflictSelections by remember { mutableStateOf(setOf<String>()) }
     var conflictKeepExisting by remember { mutableStateOf(setOf<String>()) }
-
-    val publishBackupProgress: suspend (SettingsBackupManager.ImportProgress) -> Unit = { progress ->
-        withContext(Dispatchers.Main.immediate) {
-            backupProgress = progress
-        }
-    }
 
     fun importBackup(
         uri: Uri,
@@ -228,39 +211,18 @@ fun MiuixSettingsScreen(
         selectedSensitiveItemIds: Set<String>,
         sensitivePassword: CharArray? = null
     ) {
-        if (backupProgressRequest != null) return
-        backupProgressRequest = BackupProgressRequest(
-            mode = BackupProgressMode.IMPORT,
-            isZip = preview.isZip,
-            selectedLeafIds = selectedLeafIds,
-            selectedSensitiveItemIds = selectedSensitiveItemIds,
-        )
-        backupProgress = SettingsBackupManager.ImportProgress(
-            SettingsBackupManager.ImportStage.READING_BACKUP
-        )
+        if (backupImportCoordinator.isBusy) return
         coroutineScope.launch {
             val result = try {
-                if (preview.isZip) {
-                    SettingsBackupManager.importFromZip(
-                        context,
-                        uri,
-                        selectedLeafIds,
-                        selectedSensitiveItemIds,
-                        sensitivePassword,
-                        publishBackupProgress
-                    )
-                } else {
-                    SettingsBackupManager.importSelected(
-                        context,
-                        uri,
-                        selectedLeafIds,
-                        publishBackupProgress
-                    )
-                }
+                backupImportCoordinator.importSelected(
+                    uri = uri,
+                    preview = preview,
+                    selectedLeafIds = selectedLeafIds,
+                    selectedSensitiveItemIds = selectedSensitiveItemIds,
+                    sensitivePassword = sensitivePassword,
+                )
             } finally {
                 if (!preview.isZip) sensitivePassword?.fill('\u0000')
-                backupProgressRequest = null
-                backupProgress = null
             }
             if (result.success && result.parserConflicts.isNotEmpty()) {
                 parserConflicts = result.parserConflicts
@@ -346,51 +308,35 @@ fun MiuixSettingsScreen(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
         if (uri == null) return@rememberLauncherForActivityResult
-        if (backupProgressRequest != null) return@rememberLauncherForActivityResult
-        backupProgressRequest = BackupProgressRequest(
-            mode = BackupProgressMode.PREVIEW,
-            isZip = false,
-        )
-        backupProgress = SettingsBackupManager.ImportProgress(
-            SettingsBackupManager.ImportStage.READING_BACKUP
-        )
+        if (backupImportCoordinator.isBusy) return@rememberLauncherForActivityResult
         coroutineScope.launch {
-            try {
-                val preview = SettingsBackupManager.previewImportFile(
-                    context,
-                    uri,
-                    publishBackupProgress
-                )
-                if (preview.success) {
-                    importPreviewResult = preview
-                    pendingImportUri = uri
-                    val parserJson = ParserBackupPreviewReader.read(context, uri)
-                    val dynamicCategoriesList = BackupCategories.ALL_CATEGORIES.map { cat ->
-                        when (cat.id) {
-                            "parser_rules" -> cat.copy(
-                                subGroups = BackupCategories.parserAppSubGroupsFromJson(parserJson)
-                            )
-                            else -> cat
-                        }
+            val preview = backupImportCoordinator.preview(uri)
+            if (preview.success) {
+                importPreviewResult = preview
+                pendingImportUri = uri
+                val parserJson = ParserBackupPreviewReader.read(context, uri)
+                val dynamicCategoriesList = BackupCategories.ALL_CATEGORIES.map { cat ->
+                    when (cat.id) {
+                        "parser_rules" -> cat.copy(
+                            subGroups = BackupCategories.parserAppSubGroupsFromJson(parserJson)
+                        )
+                        else -> cat
                     }
-                    selectedImportCategories = preview.categoryCounts.keys.flatMap { catId ->
-                        val cat = dynamicCategoriesList.find { it.id == catId }
-                        if (cat != null && cat.subGroups.isNotEmpty()) {
-                            cat.subGroups.map { it.id }
-                        } else {
-                            listOf(catId)
-                        }
-                    }.toSet()
-                    if (preview.lyricCacheEntryCount != 0) {
-                        selectedImportCategories = selectedImportCategories + "lyric_cache"
-                    }
-                    showImportPreviewDialog = true
-                } else {
-                    snackbarHostState.showSnackbar(message = backupImportFailedText)
                 }
-            } finally {
-                backupProgressRequest = null
-                backupProgress = null
+                selectedImportCategories = preview.categoryCounts.keys.flatMap { catId ->
+                    val cat = dynamicCategoriesList.find { it.id == catId }
+                    if (cat != null && cat.subGroups.isNotEmpty()) {
+                        cat.subGroups.map { it.id }
+                    } else {
+                        listOf(catId)
+                    }
+                }.toSet()
+                if (preview.lyricCacheEntryCount != 0) {
+                    selectedImportCategories = selectedImportCategories + "lyric_cache"
+                }
+                showImportPreviewDialog = true
+            } else {
+                snackbarHostState.showSnackbar(message = backupImportFailedText)
             }
         }
     }
@@ -1325,51 +1271,23 @@ fun MiuixSettingsScreen(
             }
         }
 
-        backupProgressRequest?.let { request ->
-            backupProgress?.let { progress ->
-                MiuixBackupImportProgressDialog(
-                    request = request,
-                    progress = progress,
-                )
-            }
+        backupImportCoordinator.status?.let { status ->
+            MiuixBackupImportProgressDialog(status = status)
         }
     }
 }
 
 @Composable
-private fun MiuixBackupImportProgressDialog(
-    request: BackupProgressRequest,
-    progress: SettingsBackupManager.ImportProgress,
+internal fun MiuixBackupImportProgressDialog(
+    status: BackupImportStatus,
 ) {
-    val stages = buildList {
-        add(SettingsBackupManager.ImportStage.READING_BACKUP)
-        if (request.mode == BackupProgressMode.PREVIEW) {
-            if (progress.stage == SettingsBackupManager.ImportStage.EXTRACTING_ARCHIVE) {
-                add(SettingsBackupManager.ImportStage.EXTRACTING_ARCHIVE)
-            }
-        } else {
-            if (request.isZip) add(SettingsBackupManager.ImportStage.EXTRACTING_ARCHIVE)
-            add(SettingsBackupManager.ImportStage.IMPORTING_SETTINGS)
-            if (
-                request.selectedLeafIds.any { it.startsWith("parser_") } ||
-                progress.stage == SettingsBackupManager.ImportStage.IMPORTING_PARSER_RULES
-            ) {
-                add(SettingsBackupManager.ImportStage.IMPORTING_PARSER_RULES)
-            }
-            if (request.selectedLeafIds.contains("lyric_cache")) {
-                add(SettingsBackupManager.ImportStage.IMPORTING_LYRIC_CACHE)
-            }
-            if (request.selectedSensitiveItemIds.isNotEmpty()) {
-                add(SettingsBackupManager.ImportStage.RESTORING_SENSITIVE_DATA)
-            }
-        }
-    }
-    val currentIndex = stages.indexOf(progress.stage).let { if (it >= 0) it else 0 }
+    val stages = status.visibleStages()
+    val currentIndex = stages.indexOf(status.progress.stage).let { if (it >= 0) it else 0 }
 
     MiuixBlurDialog(
         show = true,
         title = stringResource(
-            if (request.mode == BackupProgressMode.PREVIEW) {
+            if (status.operation == BackupImportOperation.PREVIEW) {
                 R.string.backup_progress_preview_title
             } else {
                 R.string.backup_progress_import_title
@@ -1473,7 +1391,7 @@ private fun miuixBackupProgressStageLabel(stage: SettingsBackupManager.ImportSta
 }
 
 @Composable
-private fun MiuixSensitiveBackupPasswordDialog(
+internal fun MiuixSensitiveBackupPasswordDialog(
     title: String,
     description: String,
     requireConfirmation: Boolean,


### PR DESCRIPTION
- 修复 OOBE 导入备份时没有进度条的问题
- 将各页面重复的分阶段进度逻辑提取为公共实现
- 由 Material、Miuix 和 OOBE 共用同一套进度机制（以前的逻辑是每套ui都有一套独立的进度条逻辑）
- 删除两个已经不用的导入方法
- OOBE 复用现有的备份读取逻辑