### PR TITLE
fix：优化备份导入体验

### DIFF
--- a/app/src/main/java/com/example/islandlyrics/core/settings/SettingsBackupManager.kt
+++ b/app/src/main/java/com/example/islandlyrics/core/settings/SettingsBackupManager.kt
@@ -82,6 +82,7 @@ object SettingsBackupManager {
 
     enum class ImportStage {
         READING_BACKUP,
+        VERIFYING_SENSITIVE_DATA,
         EXTRACTING_ARCHIVE,
         IMPORTING_SETTINGS,
         IMPORTING_PARSER_RULES,
@@ -256,6 +257,7 @@ object SettingsBackupManager {
                         "A sensitive backup password is required"
                     }
                     require(password.isNotEmpty()) { "A sensitive backup password is required" }
+                    onProgress(ImportProgress(ImportStage.VERIFYING_SENSITIVE_DATA))
                     prepareSensitiveImport(context, uri, sensitiveItemIds, password)
                 }
 

--- a/app/src/main/java/com/example/islandlyrics/feature/oobe/miuix/MiuixOobeScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/oobe/miuix/MiuixOobeScreen.kt
@@ -261,7 +261,18 @@ fun MiuixOobeScreen(
                 }
                 onImportAndFinish(message)
             } else {
-                Toast.makeText(context, backupImportFailedText, Toast.LENGTH_SHORT).show()
+                if (selectedSensitiveItemIds.isNotEmpty()) {
+                    showSensitiveImportPasswordDialog = true
+                }
+                Toast.makeText(
+                    context,
+                    if (selectedSensitiveItemIds.isNotEmpty()) {
+                        sensitivePasswordInvalidText
+                    } else {
+                        backupImportFailedText
+                    },
+                    Toast.LENGTH_SHORT
+                ).show()
             }
         }
     }
@@ -509,16 +520,7 @@ fun MiuixOobeScreen(
             description = stringResource(R.string.backup_sensitive_password_import_description),
             requireConfirmation = false,
             onSubmit = { password ->
-                val uri = pendingImportUri
-                val preview = pendingImportPreview
-                val valid = uri != null && preview != null &&
-                    SettingsBackupManager.verifySensitiveImport(
-                        context,
-                        uri,
-                        selectedSensitiveImportItems,
-                        password.toCharArray()
-                    )
-                if (!valid) {
+                if (pendingImportUri == null || pendingImportPreview == null) {
                     sensitivePasswordInvalidText
                 } else {
                     pendingSensitiveImportPassword?.fill('\u0000')
@@ -534,10 +536,6 @@ fun MiuixOobeScreen(
                 val selectedSensitiveItems = selectedSensitiveImportItems
                 val selectedLeafIds = selectedImportCategories - selectedSensitiveItems
                 pendingSensitiveImportPassword = null
-                pendingImportUri = null
-                pendingImportPreview = null
-                selectedSensitiveImportItems = emptySet()
-                selectedImportCategories = emptySet()
                 if (uri != null && preview != null && password != null) {
                     importOobeBackup(
                         uri,

--- a/app/src/main/java/com/example/islandlyrics/feature/settings/ParserBackupPreviewReader.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/settings/ParserBackupPreviewReader.kt
@@ -239,6 +239,12 @@ fun BackupImportStatus.visibleStages(): List<ImportStage> {
             return@buildList
         }
 
+        if (
+            selectedSensitiveItemIds.isNotEmpty() ||
+                progress.stage == ImportStage.VERIFYING_SENSITIVE_DATA
+        ) {
+            add(ImportStage.VERIFYING_SENSITIVE_DATA)
+        }
         if (isZip || progress.stage == ImportStage.EXTRACTING_ARCHIVE) {
             add(ImportStage.EXTRACTING_ARCHIVE)
         }

--- a/app/src/main/java/com/example/islandlyrics/feature/settings/material/SettingsScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/settings/material/SettingsScreen.kt
@@ -195,7 +195,10 @@ fun SettingsScreen(
         selectedSensitiveItemIds: Set<String>,
         sensitivePassword: CharArray? = null
     ) {
-        if (backupImportCoordinator.isBusy) return
+        if (backupImportCoordinator.isBusy) {
+            sensitivePassword?.fill('\u0000')
+            return
+        }
         coroutineScope.launch {
             val result = try {
                 backupImportCoordinator.importSelected(
@@ -215,6 +218,10 @@ fun SettingsScreen(
                 conflictKeepExisting = emptySet()
                 showParserConflictDialog = true
             } else {
+                val sensitiveImportFailed = !result.success && selectedSensitiveItemIds.isNotEmpty()
+                if (sensitiveImportFailed) {
+                    showSensitiveImportPasswordDialog = true
+                }
                 val message = if (result.success) {
                     if (result.sensitiveItemCount > 0) {
                         String.format(
@@ -235,13 +242,19 @@ fun SettingsScreen(
                         String.format(Locale.getDefault(), backupImportSuccessFormat, result.importedCount)
                     }
                 } else {
-                    backupImportFailedText
+                    if (selectedSensitiveItemIds.isNotEmpty()) {
+                        sensitivePasswordInvalidText
+                    } else {
+                        backupImportFailedText
+                    }
                 }
                 snackbarHostState.showSnackbar(message)
             }
-            selectedSensitiveImportItems = emptySet()
-            pendingImportUri = null
-            importPreviewResult = null
+            if (result.success || selectedSensitiveItemIds.isEmpty()) {
+                selectedSensitiveImportItems = emptySet()
+                pendingImportUri = null
+                importPreviewResult = null
+            }
         }
     }
 
@@ -948,15 +961,7 @@ fun SettingsScreen(
                 description = stringResource(R.string.backup_sensitive_password_import_description),
                 requireConfirmation = false,
                 onSubmit = { password ->
-                    val uri = pendingImportUri
-                    val preview = importPreviewResult
-                    if (uri == null || preview == null || !SettingsBackupManager.verifySensitiveImport(
-                            context,
-                            uri,
-                            selectedSensitiveImportItems,
-                            password.toCharArray()
-                        )
-                    ) {
+                    if (pendingImportUri == null || importPreviewResult == null) {
                         sensitivePasswordInvalidText
                     } else {
                         pendingSensitiveImportPassword?.fill('\u0000')
@@ -1183,6 +1188,7 @@ private fun backupProgressStageLabel(stage: SettingsBackupManager.ImportStage): 
     return stringResource(
         when (stage) {
             SettingsBackupManager.ImportStage.READING_BACKUP -> R.string.backup_progress_reading
+            SettingsBackupManager.ImportStage.VERIFYING_SENSITIVE_DATA -> R.string.backup_progress_verifying
             SettingsBackupManager.ImportStage.EXTRACTING_ARCHIVE -> R.string.backup_progress_extracting
             SettingsBackupManager.ImportStage.IMPORTING_SETTINGS -> R.string.backup_progress_settings
             SettingsBackupManager.ImportStage.IMPORTING_PARSER_RULES -> R.string.backup_progress_parser_rules
@@ -1890,8 +1896,8 @@ private fun SensitiveBackupPasswordDialog(
                         password.isBlank() -> error = requiredText
                         requireConfirmation && password != confirmation -> error = mismatchText
                         else -> {
+                            submitting = true
                             coroutineScope.launch {
-                                submitting = true
                                 val submitError = try {
                                     onSubmit(password)
                                 } catch (_: Exception) {
@@ -1915,7 +1921,7 @@ private fun SensitiveBackupPasswordDialog(
             }
         },
         dismissButton = {
-            TextButton(enabled = !submitting, onClick = onDismiss) {
+            TextButton(enabled = !submitting, onClick = { if (!submitting) onDismiss() }) {
                 Text(stringResource(R.string.backup_dialog_cancel))
             }
         }

--- a/app/src/main/java/com/example/islandlyrics/feature/settings/miuix/MiuixSettingsScreen.kt
+++ b/app/src/main/java/com/example/islandlyrics/feature/settings/miuix/MiuixSettingsScreen.kt
@@ -211,7 +211,10 @@ fun MiuixSettingsScreen(
         selectedSensitiveItemIds: Set<String>,
         sensitivePassword: CharArray? = null
     ) {
-        if (backupImportCoordinator.isBusy) return
+        if (backupImportCoordinator.isBusy) {
+            sensitivePassword?.fill('\u0000')
+            return
+        }
         coroutineScope.launch {
             val result = try {
                 backupImportCoordinator.importSelected(
@@ -231,6 +234,10 @@ fun MiuixSettingsScreen(
                 conflictKeepExisting = emptySet()
                 showParserConflictDialog = true
             } else {
+                val sensitiveImportFailed = !result.success && selectedSensitiveItemIds.isNotEmpty()
+                if (sensitiveImportFailed) {
+                    showSensitiveImportPasswordDialog = true
+                }
                 val message = if (result.success) {
                     if (result.sensitiveItemCount > 0) {
                         String.format(
@@ -251,13 +258,19 @@ fun MiuixSettingsScreen(
                         String.format(Locale.getDefault(), backupImportSuccessFormat, result.importedCount)
                     }
                 } else {
-                    backupImportFailedText
+                    if (selectedSensitiveItemIds.isNotEmpty()) {
+                        sensitivePasswordInvalidText
+                    } else {
+                        backupImportFailedText
+                    }
                 }
                 snackbarHostState.showSnackbar(message = message)
             }
-            selectedSensitiveImportItems = emptySet()
-            pendingImportUri = null
-            importPreviewResult = null
+            if (result.success || selectedSensitiveItemIds.isEmpty()) {
+                selectedSensitiveImportItems = emptySet()
+                pendingImportUri = null
+                importPreviewResult = null
+            }
         }
     }
 
@@ -1141,15 +1154,7 @@ fun MiuixSettingsScreen(
                 description = stringResource(R.string.backup_sensitive_password_import_description),
                 requireConfirmation = false,
                 onSubmit = { password ->
-                    val uri = pendingImportUri
-                    val preview = importPreviewResult
-                    if (uri == null || preview == null || !SettingsBackupManager.verifySensitiveImport(
-                            context,
-                            uri,
-                            selectedSensitiveImportItems,
-                            password.toCharArray()
-                        )
-                    ) {
+                    if (pendingImportUri == null || importPreviewResult == null) {
                         sensitivePasswordInvalidText
                     } else {
                         pendingSensitiveImportPassword?.fill('\u0000')
@@ -1381,6 +1386,7 @@ private fun miuixBackupProgressStageLabel(stage: SettingsBackupManager.ImportSta
     return stringResource(
         when (stage) {
             SettingsBackupManager.ImportStage.READING_BACKUP -> R.string.backup_progress_reading
+            SettingsBackupManager.ImportStage.VERIFYING_SENSITIVE_DATA -> R.string.backup_progress_verifying
             SettingsBackupManager.ImportStage.EXTRACTING_ARCHIVE -> R.string.backup_progress_extracting
             SettingsBackupManager.ImportStage.IMPORTING_SETTINGS -> R.string.backup_progress_settings
             SettingsBackupManager.ImportStage.IMPORTING_PARSER_RULES -> R.string.backup_progress_parser_rules
@@ -1432,6 +1438,7 @@ internal fun MiuixSensitiveBackupPasswordDialog(
                 },
                 label = stringResource(R.string.backup_sensitive_password),
                 visualTransformation = PasswordVisualTransformation(),
+                enabled = !submitting,
                 modifier = Modifier.fillMaxWidth()
             )
             if (requireConfirmation) {
@@ -1443,6 +1450,7 @@ internal fun MiuixSensitiveBackupPasswordDialog(
                     },
                     label = stringResource(R.string.backup_sensitive_password_confirm),
                     visualTransformation = PasswordVisualTransformation(),
+                    enabled = !submitting,
                     modifier = Modifier.fillMaxWidth()
                 )
             }
@@ -1462,6 +1470,7 @@ internal fun MiuixSensitiveBackupPasswordDialog(
                     onClick = {
                         if (!submitting) onDismiss()
                     },
+                    enabled = !submitting,
                     modifier = Modifier.weight(1f),
                     colors = ButtonDefaults.textButtonColors(
                         textColor = MiuixTheme.colorScheme.onSurfaceVariantActions
@@ -1476,8 +1485,8 @@ internal fun MiuixSensitiveBackupPasswordDialog(
                                 password.isBlank() -> error = requiredText
                                 requireConfirmation && password != confirmation -> error = mismatchText
                                 else -> {
+                                    submitting = true
                                     coroutineScope.launch {
-                                        submitting = true
                                         val submitError = try {
                                             onSubmit(password)
                                         } catch (_: Exception) {

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -500,6 +500,7 @@
     <string name="backup_progress_preview_title">正在讀取備份</string>
     <string name="backup_progress_import_title">正在還原備份</string>
     <string name="backup_progress_reading">正在讀取備份檔案</string>
+    <string name="backup_progress_verifying">正在驗證備份密碼</string>
     <string name="backup_progress_extracting">正在解壓備份壓縮檔</string>
     <string name="backup_progress_settings">正在匯入應用程式設定</string>
     <string name="backup_progress_parser_rules">正在匯入解析規則</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -500,6 +500,7 @@
     <string name="backup_progress_preview_title">バックアップを読み込み中</string>
     <string name="backup_progress_import_title">バックアップを復元中</string>
     <string name="backup_progress_reading">バックアップファイルを読み込み中</string>
+    <string name="backup_progress_verifying">バックアップパスワードを検証中</string>
     <string name="backup_progress_extracting">バックアップアーカイブを展開中</string>
     <string name="backup_progress_settings">アプリ設定をインポート中</string>
     <string name="backup_progress_parser_rules">パーサールールをインポート中</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -500,6 +500,7 @@
     <string name="backup_progress_preview_title">正在读取备份</string>
     <string name="backup_progress_import_title">正在还原备份</string>
     <string name="backup_progress_reading">正在读取备份文件</string>
+    <string name="backup_progress_verifying">正在验证备份口令</string>
     <string name="backup_progress_extracting">正在解压备份压缩包</string>
     <string name="backup_progress_settings">正在导入应用设置</string>
     <string name="backup_progress_parser_rules">正在导入解析规则</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -539,6 +539,7 @@
     <string name="backup_progress_preview_title">Reading backup</string>
     <string name="backup_progress_import_title">Restoring backup</string>
     <string name="backup_progress_reading">Reading backup file</string>
+    <string name="backup_progress_verifying">Verifying backup password</string>
     <string name="backup_progress_extracting">Extracting backup archive</string>
     <string name="backup_progress_settings">Importing app settings</string>
     <string name="backup_progress_parser_rules">Importing parser rules</string>


### PR DESCRIPTION
- 将敏感备份口令验证加入导入进度条
- 新增“正在验证备份口令”进度状态
- 提交口令后立即显示导入进度
- 禁止导入过程中重复点击确认
- 验证失败后保留导入状态并支持重新输入口令